### PR TITLE
Fixed the site Github link, addresses #4

### DIFF
--- a/java/src/site/site.xml
+++ b/java/src/site/site.xml
@@ -90,7 +90,7 @@
 
 		<links>
 			<item name="GitHub project"
-				href="http://github.com/usnistgov/swid-tools/" />
+				href="http://github.com/usnistgov/metaschema-java/" />
 		</links>
 
 		<breadcrumbs>


### PR DESCRIPTION
# Committer Notes

Fixes Github link in site header

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
