### PR TITLE
change html to markdown where appropriate

### DIFF
--- a/metaschema-java-datatypes/src/main/java/gov/nist/secauto/metaschema/datatypes/markup/MarkupLine.java
+++ b/metaschema-java-datatypes/src/main/java/gov/nist/secauto/metaschema/datatypes/markup/MarkupLine.java
@@ -52,8 +52,8 @@ public class MarkupLine
     return new MarkupLine(FlexmarkFactory.instance().fromHtml(html, null, markdownParser));
   }
 
-  public static MarkupLine fromMarkdown(String html) {
-    return new MarkupLine(FlexmarkFactory.instance().fromMarkdown(html));
+  public static MarkupLine fromMarkdown(String markdown) {
+    return new MarkupLine(FlexmarkFactory.instance().fromMarkdown(markdown));
   }
 
   protected MarkupLine(Document astNode) {

--- a/metaschema-java-datatypes/src/main/java/gov/nist/secauto/metaschema/datatypes/markup/MarkupMultiline.java
+++ b/metaschema-java-datatypes/src/main/java/gov/nist/secauto/metaschema/datatypes/markup/MarkupMultiline.java
@@ -37,8 +37,8 @@ public class MarkupMultiline
     return new MarkupMultiline(FlexmarkFactory.instance().fromHtml(html));
   }
 
-  public static MarkupMultiline fromMarkdown(String html) {
-    return new MarkupMultiline(FlexmarkFactory.instance().fromMarkdown(html));
+  public static MarkupMultiline fromMarkdown(String markdown) {
+    return new MarkupMultiline(FlexmarkFactory.instance().fromMarkdown(markdown));
   }
 
   public MarkupMultiline(Document astNode) {


### PR DESCRIPTION
# Committer Notes
This is a minor change to the `fromMarkdown()` methods so that IDE code completion shows `markdown` instead of `html`.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [N/A] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N/A] Have you written new tests for your core changes, as applicable?
- [N/A] Have you included examples of how to use your new feature(s)?
- [N/A] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
