### PR TITLE
Add support for entity resolution of URIs passed to the loaders and validators

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@
 
 # Overview
 
-This page is for potential contributors to this project. It provides basic information on the project, describes the main ways people can make contributions, explains how to report issues relating to the project and projecta rtifacts, and lists pointers to additional sources of information.
+This page is for potential contributors to this project. It provides basic information on the project, describes the main ways people can make contributions, explains how to report issues relating to the project and project artifacts, and lists pointers to additional sources of information.
 
 ## Project approach
 
@@ -69,7 +69,7 @@ This project is using the GitHub project cards feature in the project's [work bo
 
 ### User Stories
 
-Development is done against a set of [user stories](../../issues?q=is%3Aopen+is%3Aissue+label%3A%22User+Story%22), that represent features, actions, or enhancements that are intended to be developed. Each user story is based on a [template](../../issues/new?template=feature_request.md&labels=enhancement%2C+User+Story) and describes the basic problem or need to be addressed, a set of detailed goals to accomplish, any dependencies that must be addressed to start or complete the user story, and the criteria for acceptance of the contribution. Each user story is organized against a developmental [milestone](https://github.com/usnistgov/metaschema-java/milestones), indicating the release for which the user story is planned to be addressed.
+Development is done against a set of [user stories](../../issues?q=is%3Aopen+is%3Aissue+label%3A%22User+Story%22), that represent features, actions, or enhancements that are intended to be developed. Each user story is based on a [template](../../issues/new?template=feature_request.md&labels=enhancement%2C+User+Story) and describes the basic problem or need to be addressed, a set of detailed goals to accomplish, any dependencies that must be addressed to start or complete the user story, and the criteria for acceptance of the contribution. Each user story is organized against a developmental [milestone](../../milestones), indicating the release for which the user story is planned to be addressed.
 
 The goals in a user story will be bulleted, indicating that each goal can be worked on in parallel, or numbered, indicating that each goal must be worked on sequentially. Each goal will be assigned to one or more individuals to accomplish.
 
@@ -97,7 +97,7 @@ Note: A pull request must be submitted for all goals before an issue will be mov
 
 This project originated as part of the [Open Security Controls Assessment Language](https://pages.nist.gov/OSCAL/) (OSCAL) project. We use the OSCAL communications channels for this project as well.
 
-A Gitter [chat room](https://gitter.im/usnistgov-OSCAL/metaschema) is available for Metaschema-related discussions. This is a great place to discuss issues pertaining to this work with the community working with Metaschema. The NIST OSCAL team actively chats on the OSCAL Gitter. This room is also setup with Github integration, which provides a good summary of recent Github repo activities within the chat room.
+A Gitter [chat room](https://gitter.im/usnistgov-OSCAL/metaschema) is available for Metaschema-related discussions. This is a great place to discuss issues pertaining to this work with the community. The NIST OSCAL team actively chats on the OSCAL Gitter. This room is also setup with Github integration, which provides a good summary of recent Github repo activities within the chat room.
 
 There are two OSCAL mailing lists, which are also used for this project.
 

--- a/metaschema-freemarker-support/pom.xml
+++ b/metaschema-freemarker-support/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.7.1-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metaschema-freemarker-support</artifactId>

--- a/metaschema-java-binding/pom.xml
+++ b/metaschema-java-binding/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.7.1-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metaschema-java-binding</artifactId>

--- a/metaschema-java-codegen/pom.xml
+++ b/metaschema-java-codegen/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.7.1-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metaschema-java-codegen</artifactId>

--- a/metaschema-maven-plugin/pom.xml
+++ b/metaschema-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.7.1-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metaschema-maven-plugin</artifactId>

--- a/metaschema-model-common/pom.xml
+++ b/metaschema-model-common/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.7.1-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metaschema-model-common</artifactId>

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/io/IResourceLoader.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/io/IResourceLoader.java
@@ -23,44 +23,28 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
+package gov.nist.secauto.metaschema.model.common.io;
 
-package gov.nist.secauto.metaschema.model.common.metapath;
-
-import gov.nist.secauto.metaschema.model.common.io.IResourceLoader;
-import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
-import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
+import gov.nist.secauto.metaschema.model.common.util.InputSourceUtils;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Path;
+import java.net.URI;
 
-public interface IDocumentLoader extends IResourceLoader {
+public interface IResourceLoader {
   @Nullable
-  EntityResolver setEntityResolver(@NotNull EntityResolver resolver);
-  
-  @NotNull
-  default IDocumentNodeItem loadAsNodeItem(@NotNull URL url) throws IOException, URISyntaxException {
-    return loadAsNodeItem(toInputSource(ObjectUtils.notNull(url.toURI())));
+  default EntityResolver getEntityResolver() {
+    // by default, do not support an entity resolver extension mechanism
+    // Subclasses can override this behavior
+    return null;
   }
 
   @NotNull
-  default IDocumentNodeItem loadAsNodeItem(@NotNull Path path) throws IOException {
-    return loadAsNodeItem(toInputSource(ObjectUtils.notNull(path.toUri())));
+  default InputSource toInputSource(@NotNull URI uri) throws IOException {
+    return InputSourceUtils.toInputSource(uri, getEntityResolver());
   }
-
-  @NotNull
-  default IDocumentNodeItem loadAsNodeItem(@NotNull File file) throws IOException {
-    return loadAsNodeItem(toInputSource(ObjectUtils.notNull(file.toPath().toUri())));
-  }
-
-  @NotNull
-  IDocumentNodeItem loadAsNodeItem(@NotNull InputSource source) throws IOException;
-
 }

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/io/package-info.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/io/package-info.java
@@ -24,43 +24,4 @@
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
 
-package gov.nist.secauto.metaschema.model.common.metapath;
-
-import gov.nist.secauto.metaschema.model.common.io.IResourceLoader;
-import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
-import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.xml.sax.EntityResolver;
-import org.xml.sax.InputSource;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Path;
-
-public interface IDocumentLoader extends IResourceLoader {
-  @Nullable
-  EntityResolver setEntityResolver(@NotNull EntityResolver resolver);
-  
-  @NotNull
-  default IDocumentNodeItem loadAsNodeItem(@NotNull URL url) throws IOException, URISyntaxException {
-    return loadAsNodeItem(toInputSource(ObjectUtils.notNull(url.toURI())));
-  }
-
-  @NotNull
-  default IDocumentNodeItem loadAsNodeItem(@NotNull Path path) throws IOException {
-    return loadAsNodeItem(toInputSource(ObjectUtils.notNull(path.toUri())));
-  }
-
-  @NotNull
-  default IDocumentNodeItem loadAsNodeItem(@NotNull File file) throws IOException {
-    return loadAsNodeItem(toInputSource(ObjectUtils.notNull(file.toPath().toUri())));
-  }
-
-  @NotNull
-  IDocumentNodeItem loadAsNodeItem(@NotNull InputSource source) throws IOException;
-
-}
+package gov.nist.secauto.metaschema.model.common.io;

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/function/library/FnDoc.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/function/library/FnDoc.java
@@ -42,6 +42,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 
 public final class FnDoc {
@@ -120,7 +121,7 @@ public final class FnDoc {
 
     try {
       return context.getDocumentLoader().loadAsNodeItem(ObjectUtils.notNull(documentUri.toURL()));
-    } catch (IOException ex) {
+    } catch (IOException | URISyntaxException ex) {
       throw new DocumentFunctionException(DocumentFunctionException.ERROR_RETRIEVING_RESOURCE, String
           .format("Unable to retrieve the resource identified by the URI '%s'.", documentUri.toString()), ex);
     }

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/util/CollectionUtil.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/util/CollectionUtil.java
@@ -27,6 +27,7 @@
 package gov.nist.secauto.metaschema.model.common.util;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -152,7 +153,7 @@ public final class CollectionUtil {
   }
 
   @NotNull
-  public static <T> List<T> listOrEmpty(List<T> list) {
+  public static <T> List<T> listOrEmpty(@Nullable List<T> list) {
     return list == null ? emptyList() : list;
   }
 

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/util/InputSourceUtils.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/util/InputSourceUtils.java
@@ -23,40 +23,37 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
-
-package gov.nist.secauto.metaschema.model.common.validation;
+package gov.nist.secauto.metaschema.model.common.util;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 
-public abstract class AbstractContentValidator implements IContentValidator {
-
-  @SuppressWarnings("null")
-  @Override
-  public IValidationResult validate(@NotNull Path path) throws IOException {
-    try (InputStream is = Files.newInputStream(path, StandardOpenOption.READ)) {
-      return validate(is, path.toUri());
-    }
+public final class InputSourceUtils {
+  private InputSourceUtils() {
+    // disable construction
   }
 
-  @SuppressWarnings("null")
-  @Override
-  public IValidationResult validate(@NotNull URL url) throws IOException, URISyntaxException {
-    try (InputStream is = url.openStream()) {
-      return validate(is, url.toURI());
-    }
-  }
-
-  @Override
   @NotNull
-  public abstract IValidationResult validate(@NotNull InputStream is, @NotNull URI documentUri) throws IOException;
-
+  public static InputSource toInputSource(@NotNull URI uri, @Nullable EntityResolver entityResolver) throws IOException {
+    InputSource retval = null;
+    if (entityResolver != null) {
+      // attempt to resolve the entity
+      try {
+        retval = entityResolver.resolveEntity(null, uri.toASCIIString());
+      } catch (SAXException  ex) {
+        throw new IOException(ex);
+      }
+    }
+    if (retval == null) {
+      // fall back to using the provided URI
+      retval = new InputSource(uri.toASCIIString());
+    }
+    return retval;
+  }
 }

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/validation/IContentValidator.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/validation/IContentValidator.java
@@ -26,11 +26,13 @@
 
 package gov.nist.secauto.metaschema.model.common.validation;
 
+import gov.nist.secauto.metaschema.model.common.io.IResourceLoader;
+import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
+
 import org.jetbrains.annotations.NotNull;
+import org.xml.sax.InputSource;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -38,7 +40,7 @@ import java.nio.file.Path;
 /**
  * A common interface for Metaschema related content validators.
  */
-public interface IContentValidator {
+public interface IContentValidator extends IResourceLoader {
   /**
    * Validate the resource at provided {@code path}.
    * 
@@ -49,7 +51,9 @@ public interface IContentValidator {
    *           if an error occurred while performing validation
    */
   @NotNull
-  IValidationResult validate(@NotNull Path path) throws IOException;
+  default IValidationResult validate(@NotNull Path path) throws IOException {
+    return validate(toInputSource(ObjectUtils.notNull(path.toUri())));
+  }
 
   /**
    * Validate the resource at provided {@code path}.
@@ -63,19 +67,19 @@ public interface IContentValidator {
    *           if there is a problem with the provided {@code url}
    */
   @NotNull
-  IValidationResult validate(@NotNull URL url) throws IOException, URISyntaxException;
+  default IValidationResult validate(@NotNull URL url) throws IOException, URISyntaxException {
+    return validate(toInputSource(ObjectUtils.notNull(url.toURI())));
+  }
 
   /**
    * Validate the resource associated with the provided input stream {@code is}.
    * 
-   * @param is
-   *          the input stream to read content to validate from
-   * @param documentUri
-   *          the URI of the resource to validate
+   * @param source
+   *          information about how to access the resource
    * @return the result of the validation
    * @throws IOException
    *           if an error occurred while performing validation
    */
   @NotNull
-  IValidationResult validate(@NotNull InputStream is, @NotNull URI documentUri) throws IOException;
+  IValidationResult validate(@NotNull InputSource source) throws IOException;
 }

--- a/metaschema-model/pom.xml
+++ b/metaschema-model/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.7.1-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metaschema-model</artifactId>

--- a/metaschema-schema-generator/pom.xml
+++ b/metaschema-schema-generator/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.7.1-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metaschema-schema-generator</artifactId>

--- a/metaschema-testing/pom.xml
+++ b/metaschema-testing/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.7.1-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>metaschema-testing</artifactId>
 	<name>Metaschema Unit Testing Support</name>

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/AbstractTestSuite.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/AbstractTestSuite.java
@@ -327,7 +327,12 @@ public abstract class AbstractTestSuite {
   @SuppressWarnings("unchecked")
   protected Path convertContent(URI contentUri, @NotNull Path generationPath, @NotNull DynamicBindingContext context)
       throws IOException {
-    Object object = context.newBoundLoader().load(contentUri.toURL());
+    Object object;
+    try {
+      object = context.newBoundLoader().load(contentUri.toURL());
+    } catch (URISyntaxException ex) {
+      throw new IOException(ex);
+    }
 
     if (!Files.exists(generationPath)) {
       Files.createDirectories(generationPath);

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<groupId>gov.nist.secauto.metaschema</groupId>
 	<artifactId>metaschema-framework</artifactId>
-	<version>0.7.1-SNAPSHOT</version>
+	<version>0.8.0-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
# Committer Notes

Added support for entity resolution of URIs passed to the loaders and validators. Partially addresses usnistgov/liboscal-java#12.
Exposed URISyntaxExceptions on all loader URI-based methods.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
