### PR TITLE
Don't autoclose stream when using Jackson

### DIFF
--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/IBoundLoader.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/IBoundLoader.java
@@ -88,6 +88,25 @@ public interface IBoundLoader extends IDocumentLoader, IMutableConfiguration {
   default Format detectFormat(@NotNull File file) throws IOException {
     return detectFormat(ObjectUtils.notNull(file.toPath()));
   }
+  /**
+   * Determine the format of the provided resource.
+   * <p>
+   * This method will consume data from the provided {@link InputStream}. If the caller of this method
+   * intends to read data from the stream after determining the format, the caller should pass in a
+   * stream that can be reset.
+   * <p>
+   * This method will not close the provided {@link InputStream}, since it does not own the stream.
+   * 
+   * @param is
+   *          an input stream for the resource
+   * @return the format of the provided resource
+   * @throws IOException
+   *           if an error occurred while reading the resource
+   */
+  @NotNull
+  default Format detectFormat(@NotNull InputStream is) throws IOException {
+    return detectFormat(new InputSource(is));
+  }
 
   /**
    * Determine the format of the provided resource.
@@ -164,6 +183,29 @@ public interface IBoundLoader extends IDocumentLoader, IMutableConfiguration {
   @NotNull
   default <CLASS> CLASS load(@NotNull File file) throws IOException {
     return loadAsNodeItem(file).toBoundObject();
+  }
+
+  /**
+   * Load data from the provided resource into a bound object.
+   * <p>
+   * This method should auto-detect the format of the provided resource.
+   * <p>
+   * This method will not close the provided {@link InputStream}, since it does not own the stream.
+   * 
+   * @param <CLASS>
+   *          the type of the bound object to return
+   * @param is
+   *          the resource
+   * @param documentUri
+   *          the URI of the resource
+   * @return a bound object containing the loaded data
+   * @throws IOException
+   *           if an error occurred while reading the resource
+   * @see #detectFormat(InputStream)
+   */
+  @NotNull
+  default <CLASS> CLASS load(@NotNull InputStream is, @NotNull URI documentUri) throws IOException {
+    return loadAsNodeItem(is, documentUri).toBoundObject();
   }
 
   /**

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/DefaultJsonDeserializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/DefaultJsonDeserializer.java
@@ -79,7 +79,10 @@ public class DefaultJsonDeserializer<CLASS>
   @SuppressWarnings("null")
   @NotNull
   protected JsonParser newJsonParser(@NotNull Reader reader) throws IOException {
-    return getJsonFactory().createParser(reader);
+    JsonParser retval = getJsonFactory().createParser(reader);
+    retval.configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, false);
+    return retval;
+
   }
 
   @Override

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/DefaultJsonSerializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/DefaultJsonSerializer.java
@@ -72,6 +72,7 @@ public class DefaultJsonSerializer<CLASS>
   protected JsonGenerator newJsonGenerator(Writer writer) throws IOException {
     JsonFactory factory = getJsonFactory();
     JsonGenerator retval = factory.createGenerator(writer);
+    retval.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
     retval.setPrettyPrinter(new DefaultPrettyPrinter());
     return retval;
   }

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/IDocumentLoader.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/IDocumentLoader.java
@@ -37,6 +37,8 @@ import org.xml.sax.InputSource;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -58,6 +60,13 @@ public interface IDocumentLoader extends IResourceLoader {
   @NotNull
   default IDocumentNodeItem loadAsNodeItem(@NotNull File file) throws IOException {
     return loadAsNodeItem(toInputSource(ObjectUtils.notNull(file.toPath().toUri())));
+  }
+
+  @NotNull
+  default IDocumentNodeItem loadAsNodeItem(@NotNull InputStream is, @NotNull URI documentUri) throws IOException {
+    InputSource source = toInputSource(documentUri);
+    source.setByteStream(is);
+    return loadAsNodeItem(source);
   }
 
   @NotNull


### PR DESCRIPTION
# Committer Notes

By default, Jackson auto-closes the provided stream. This PR changes this default behavior when used in the serializer/deserializer.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
