### PR TITLE
Make xml declaration quotes consistent

### DIFF
--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/xml/DefaultXmlSerializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/xml/DefaultXmlSerializer.java
@@ -26,6 +26,7 @@
 
 package gov.nist.secauto.metaschema.binding.io.xml;
 
+import com.ctc.wstx.api.WstxOutputProperties;
 import com.ctc.wstx.stax.WstxOutputFactory;
 
 import gov.nist.secauto.metaschema.binding.IBindingContext;
@@ -56,6 +57,7 @@ public class DefaultXmlSerializer<CLASS>
       if (xmlOutputFactory == null) {
         xmlOutputFactory = (XMLOutputFactory2) WstxOutputFactory.newInstance();
         xmlOutputFactory.configureForSpeed();
+        xmlOutputFactory.setProperty(WstxOutputProperties.P_USE_DOUBLE_QUOTES_IN_XML_DECL, true);
         xmlOutputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, true);
       }
       return xmlOutputFactory;


### PR DESCRIPTION
# Committer Notes

Configured the Woodstox output factory to use the feature "[P_USE_DOUBLE_QUOTES_IN_XML_DECL](http://fasterxml.github.io/woodstox/javadoc/5.0/com/ctc/wstx/api/WstxOutputProperties.html#P_USE_DOUBLE_QUOTES_IN_XML_DECL)". Resolves usnistgov/liboscal-java#14.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
