### PR TITLE
Use UTF8 when serializing to an OutputStream

### DIFF
--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/AbstractMetaschemaLoaderStrategy.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/AbstractMetaschemaLoaderStrategy.java
@@ -49,7 +49,6 @@ class AbstractMetaschemaLoaderStrategy implements IMetaschemaLoaderStrategy {
   @NotNull
   private final Map<@NotNull Class<?>, IClassBinding> classBindingsByClass = new HashMap<>(); // NOPMD - intentional
 
-
   protected AbstractMetaschemaLoaderStrategy(@NotNull IBindingContext bindingContext) {
     this.bindingContext = bindingContext;
   }
@@ -76,7 +75,7 @@ class AbstractMetaschemaLoaderStrategy implements IMetaschemaLoaderStrategy {
   protected IMetaschema newMetaschema(@NotNull Class<? extends AbstractBoundMetaschema> clazz) {
     return AbstractBoundMetaschema.createInstance(clazz, getBindingContext());
   }
-  
+
   @Override
   public IClassBinding getClassBinding(@NotNull Class<?> clazz) {
     IClassBinding retval;
@@ -105,7 +104,7 @@ class AbstractMetaschemaLoaderStrategy implements IMetaschemaLoaderStrategy {
     }
     return retval;
   }
-  
+
   @Override
   public Map<@NotNull Class<?>, IClassBinding> getClassBindingsByClass() {
     synchronized (this) {

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/IBindingContext.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/IBindingContext.java
@@ -55,8 +55,8 @@ import javax.xml.namespace.QName;
 public interface IBindingContext extends IMetaschemaLoaderStrategy {
 
   /**
-   * Get the singleton {@link IBindingContext} instance, which can be used to load information that binds a model to a
-   * set of Java classes.
+   * Get the singleton {@link IBindingContext} instance, which can be used to load information that
+   * binds a model to a set of Java classes.
    * 
    * @return a new binding context
    */

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/DefaultBoundLoader.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/DefaultBoundLoader.java
@@ -256,7 +256,7 @@ public class DefaultBoundLoader implements IBoundLoader {
     }
 
     IDeserializer<?> deserializer = getDeserializer(clazz, format, getConfiguration());
-    return  (IDocumentNodeItem) deserializer.deserializeToNodeItem(bis, documentUri);
+    return (IDocumentNodeItem) deserializer.deserializeToNodeItem(bis, documentUri);
   }
 
   @NotNull
@@ -379,7 +379,7 @@ public class DefaultBoundLoader implements IBoundLoader {
 
     IDeserializer<CLASS> deserializer = getDeserializer(clazz, format, getConfiguration());
     INodeItem nodeItem = deserializer.deserializeToNodeItem(bis, documentUri);
-    return (CLASS)nodeItem.getValue();
+    return (CLASS) nodeItem.getValue();
   }
 
   @NotNull

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/ISerializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/ISerializer.java
@@ -62,7 +62,7 @@ public interface ISerializer<CLASS> extends IMutableConfiguration<SerializationF
    *           if an error occurred while writing data to the stream
    */
   default void serialize(@NotNull CLASS data, @NotNull OutputStream os) throws IOException {
-    OutputStreamWriter writer = new OutputStreamWriter(os);
+    OutputStreamWriter writer = new OutputStreamWriter(os, StandardCharsets.UTF_8);
     serialize(data, writer);
     writer.flush();
   }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/xml/DefaultXmlSerializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/xml/DefaultXmlSerializer.java
@@ -84,12 +84,11 @@ public class DefaultXmlSerializer<CLASS>
   public void serialize(CLASS data, Writer writer) throws IOException {
     XMLStreamWriter2 streamWriter = newXMLStreamWriter(writer);
     IOException caughtException = null;
-      IAssemblyClassBinding classBinding = getClassBinding();
-      IXmlWritingContext writingContext = new DefaultXmlWritingContext(streamWriter);
+    IAssemblyClassBinding classBinding = getClassBinding();
+    IXmlWritingContext writingContext = new DefaultXmlWritingContext(streamWriter);
 
-      RootAssemblyDefinition root = new RootAssemblyDefinition(classBinding);
+    RootAssemblyDefinition root = new RootAssemblyDefinition(classBinding);
 
-      
     try {
       root.writeRoot(data, writingContext);
       streamWriter.flush();

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/DefaultYamlSerializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/DefaultYamlSerializer.java
@@ -32,6 +32,8 @@ import gov.nist.secauto.metaschema.binding.IBindingContext;
 import gov.nist.secauto.metaschema.binding.io.json.DefaultJsonSerializer;
 import gov.nist.secauto.metaschema.binding.model.IAssemblyClassBinding;
 
+import org.jetbrains.annotations.NotNull;
+
 public class DefaultYamlSerializer<CLASS>
     extends DefaultJsonSerializer<CLASS> {
 

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/YamlFactoryFactory.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/YamlFactoryFactory.java
@@ -37,11 +37,13 @@ public final class YamlFactoryFactory {
   }
 
   public static YAMLFactory newYamlFactoryInstance() {
-    YAMLFactory retval = new YAMLFactory();
-    // retval.enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
-    retval.enable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
-    retval.enable(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS);
-    return retval;
+
+    return YAMLFactory.builder()
+        .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+        .enable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+        .enable(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS)
+        .disable(YAMLGenerator.Feature.SPLIT_LINES)
+        .build();
   }
 
   public static YAMLFactory instance() {

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/model/AbstractNamedModelProperty.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/model/AbstractNamedModelProperty.java
@@ -89,7 +89,8 @@ abstract class AbstractNamedModelProperty // NOPMD - intentional
   // }
 
   // @Override
-  // public Stream<? extends INodeItem> getNodeItemsFromParentInstance(IRequiredValueAssemblyNodeItem parentItem,
+  // public Stream<? extends INodeItem> getNodeItemsFromParentInstance(IRequiredValueAssemblyNodeItem
+  // parentItem,
   // Object parentValue) {
   // return newNodeItems(parentItem, getPropertyInfo().getItemsFromParentInstance(parentValue));
   // }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/model/IBoundJavaField.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/model/IBoundJavaField.java
@@ -90,7 +90,6 @@ interface IBoundJavaField extends IBoundNamedInstance {
     return (Class<?>) getType();
   }
 
-
   /**
    * Get the current value from the provided {@code parentInstance} object. The provided object must
    * be of the type associated with the definition containing this property.

--- a/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/DefaultBindingContextTest.java
+++ b/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/DefaultBindingContextTest.java
@@ -23,6 +23,7 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
+
 package gov.nist.secauto.metaschema.binding;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -53,13 +54,11 @@ class DefaultBindingContextTest {
     IBindingContext bindingContext = new DefaultBindingContext(CollectionUtil.singleton(constraintSet));
     IMetaschema metaschema = bindingContext.getMetaschemaInstanceByClass(TestMetaschema.class);
 
-    IAssemblyDefinition root =  metaschema.getExportedAssemblyDefinitionByName("root");
-    
-    
+    IAssemblyDefinition root = metaschema.getExportedAssemblyDefinitionByName("root");
+
     assertNotNull(root, "root not found");
     List<? extends IConstraint> constraints = root.getConstraints();
     assertFalse(constraints.isEmpty(), "a constraint was expected");
   }
-
 
 }

--- a/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/metapath/MetapathExpressionTest.java
+++ b/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/metapath/MetapathExpressionTest.java
@@ -58,7 +58,7 @@ class MetapathExpressionTest {
     assertNotNull(result, "null result");
     assertTrue(!result.isEmpty(), "result was empty");
     assertEquals(1, result.size(), "unexpected size");
-    assertEquals(true, ((IBooleanItem)result.asList().iterator().next()).toBoolean(), "unexpected result");
+    assertEquals(true, ((IBooleanItem) result.asList().iterator().next()).toBoolean(), "unexpected result");
   }
 
 }

--- a/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/DefaultFieldValuePropertyTest.java
+++ b/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/DefaultFieldValuePropertyTest.java
@@ -201,7 +201,7 @@ class DefaultFieldValuePropertyTest {
 
   @SuppressWarnings("PMD")
   @MetaschemaField(
-      name="simple-field",
+      name = "simple-field",
       metaschema = TestMetaschema.class,
       isCollapsible = true)
   public static class SimpleField {
@@ -305,7 +305,7 @@ class DefaultFieldValuePropertyTest {
 
   @SuppressWarnings("PMD")
   @MetaschemaField(
-      name= "simple-field2", 
+      name = "simple-field2",
       metaschema = TestMetaschema.class,
       isCollapsible = true)
   public static class SimpleField2 {

--- a/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/DefaultFlagPropertyTest.java
+++ b/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/DefaultFlagPropertyTest.java
@@ -197,7 +197,8 @@ class DefaultFlagPropertyTest {
   }
 
   @SuppressWarnings("PMD")
-  @MetaschemaAssembly(name= "simple-assembly", metaschema = TestMetaschema.class, rootName = "test", rootNamespace = "http://example.com/ns")
+  @MetaschemaAssembly(name = "simple-assembly", metaschema = TestMetaschema.class, rootName = "test",
+      rootNamespace = "http://example.com/ns")
   private static class SimpleAssembly {
     @BoundFlag(useName = "id", typeAdapter = StringAdapter.class)
     private String _id;

--- a/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/test/CollapsibleFlaggedBoundField.java
+++ b/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/test/CollapsibleFlaggedBoundField.java
@@ -35,7 +35,7 @@ import gov.nist.secauto.metaschema.model.common.datatype.adapter.BooleanAdapter;
 import gov.nist.secauto.metaschema.model.common.datatype.adapter.StringAdapter;
 import gov.nist.secauto.metaschema.model.common.datatype.adapter.TokenAdapter;
 
-@MetaschemaField(name= "collapsible-flagged-bound-field", isCollapsible = true, metaschema = TestMetaschema.class)
+@MetaschemaField(name = "collapsible-flagged-bound-field", isCollapsible = true, metaschema = TestMetaschema.class)
 public class CollapsibleFlaggedBoundField {
   @JsonKey
   @BoundFlag(useName = "field-required-flag", typeAdapter = TokenAdapter.class, required = true)

--- a/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/test/EmptyBoundAssembly.java
+++ b/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/test/EmptyBoundAssembly.java
@@ -28,7 +28,7 @@ package gov.nist.secauto.metaschema.binding.model.test;
 
 import gov.nist.secauto.metaschema.binding.model.annotations.MetaschemaAssembly;
 
-@MetaschemaAssembly(name= "empty-bound-assembly", rootName = "root", metaschema = TestMetaschema.class)
+@MetaschemaAssembly(name = "empty-bound-assembly", rootName = "root", metaschema = TestMetaschema.class)
 public class EmptyBoundAssembly {
 
 }

--- a/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/test/FlaggedAssembly.java
+++ b/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/test/FlaggedAssembly.java
@@ -30,7 +30,7 @@ import gov.nist.secauto.metaschema.binding.model.annotations.BoundFlag;
 import gov.nist.secauto.metaschema.binding.model.annotations.MetaschemaAssembly;
 import gov.nist.secauto.metaschema.model.common.datatype.adapter.StringAdapter;
 
-@MetaschemaAssembly(name= "flagged-assembly", metaschema = TestMetaschema.class)
+@MetaschemaAssembly(name = "flagged-assembly", metaschema = TestMetaschema.class)
 public class FlaggedAssembly {
   @BoundFlag(useName = "id", typeAdapter = StringAdapter.class)
   private String id;

--- a/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/test/FlaggedBoundAssembly.java
+++ b/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/test/FlaggedBoundAssembly.java
@@ -32,7 +32,7 @@ import gov.nist.secauto.metaschema.binding.model.annotations.MetaschemaAssembly;
 import gov.nist.secauto.metaschema.model.common.datatype.adapter.BooleanAdapter;
 import gov.nist.secauto.metaschema.model.common.datatype.adapter.StringAdapter;
 
-@MetaschemaAssembly(name= "flagged-bound-assembly", metaschema = TestMetaschema.class)
+@MetaschemaAssembly(name = "flagged-bound-assembly", metaschema = TestMetaschema.class)
 public class FlaggedBoundAssembly {
   @JsonKey
   @BoundFlag(useName = "assembly-required-flag", typeAdapter = StringAdapter.class, required = true)

--- a/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/test/FlaggedBoundField.java
+++ b/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/test/FlaggedBoundField.java
@@ -34,7 +34,7 @@ import gov.nist.secauto.metaschema.model.common.datatype.adapter.BooleanAdapter;
 import gov.nist.secauto.metaschema.model.common.datatype.adapter.StringAdapter;
 import gov.nist.secauto.metaschema.model.common.datatype.adapter.TokenAdapter;
 
-@MetaschemaField(name= "flagged-bound-field", isCollapsible = false, metaschema = TestMetaschema.class)
+@MetaschemaField(name = "flagged-bound-field", isCollapsible = false, metaschema = TestMetaschema.class)
 public class FlaggedBoundField {
   @JsonKey
   @BoundFlag(useName = "field-required-flag", typeAdapter = TokenAdapter.class, required = true)

--- a/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/test/OnlyModelBoundAssembly.java
+++ b/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/test/OnlyModelBoundAssembly.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings("PMD")
-@MetaschemaAssembly(name= "only-model", metaschema = TestMetaschema.class)
+@MetaschemaAssembly(name = "only-model", metaschema = TestMetaschema.class)
 public class OnlyModelBoundAssembly { // NOPMD - intentional
   /*
    * ================ = simple field = ================

--- a/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/test/RootBoundAssembly.java
+++ b/metaschema-java-binding/src/test/java/gov/nist/secauto/metaschema/binding/model/test/RootBoundAssembly.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-@MetaschemaAssembly(name= "root", rootName = "root", metaschema = TestMetaschema.class)
+@MetaschemaAssembly(name = "root", rootName = "root", metaschema = TestMetaschema.class)
 public class RootBoundAssembly {
   @BoundFlag(useName = "uuid", defaultValue = "374dd648-b247-483c-afd8-a66ba8876070", typeAdapter = UuidAdapter.class)
   private UUID uuid; // NOPMD - intentional

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/INamedModelInstance.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/INamedModelInstance.java
@@ -36,8 +36,8 @@ public interface INamedModelInstance extends INamedInstance, IModelInstance {
   INamedModelDefinition getDefinition();
 
   /**
-   * Get the item values for the provided {@code instanceValue}. An instance may be singular or
-   * many valued.
+   * Get the item values for the provided {@code instanceValue}. An instance may be singular or many
+   * valued.
    * 
    * @param instanceValue
    *          the instance

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/IRootAssemblyDefinition.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/IRootAssemblyDefinition.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import javax.xml.namespace.QName;
 
 public interface IRootAssemblyDefinition extends IAssemblyDefinition {
-  
+
   @NotNull
   static <T extends IAssemblyDefinition> IRootAssemblyDefinition toRootAssemblyDefinition(@NotNull T rootDefinition) {
     return new RootAssemblyDefinitionWrapper<IAssemblyDefinition>(rootDefinition);

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/configuration/DefaultConfiguration.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/configuration/DefaultConfiguration.java
@@ -102,7 +102,7 @@ public class DefaultConfiguration<T extends Enum<T> & IConfigurationFeature>
     getFeatureSet().remove(feature);
     return this;
   }
-  
+
   @Override
   @SuppressWarnings("null")
   public IMutableConfiguration<T> applyConfiguration(@NotNull IConfiguration<T> original) {

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/ConstraintComposingVisitor.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/ConstraintComposingVisitor.java
@@ -23,6 +23,7 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
+
 package gov.nist.secauto.metaschema.model.common.constraint;
 
 import gov.nist.secauto.metaschema.model.common.metapath.item.IAssemblyNodeItem;

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/DefaultIndexHasKeyConstraint.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/DefaultIndexHasKeyConstraint.java
@@ -40,7 +40,8 @@ public class DefaultIndexHasKeyConstraint
   private final String indexName;
 
   /**
-   * Create a key reference constraint, which uses a set of key fields to build a key to match against an index.
+   * Create a key reference constraint, which uses a set of key fields to build a key to match against
+   * an index.
    * 
    * @param id
    *          the optional identifier for the constraint

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/FindingCollectingConstraintValidationHandler.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/FindingCollectingConstraintValidationHandler.java
@@ -94,7 +94,7 @@ public class FindingCollectingConstraintValidationHandler
       @NotNull List<@NotNull ? extends INodeItem> targets,
       @NotNull CharSequence message,
       Throwable cause) {
-    
+
     ConstraintValidationFinding finding = new ConstraintValidationFinding(constraints, message, cause, node, targets);
     findings.add(finding);
 

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/IAllowedValue.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/IAllowedValue.java
@@ -31,7 +31,7 @@ import gov.nist.secauto.metaschema.model.common.datatype.markup.MarkupLine;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Represents an individual enumerated value associated with an {@link IAllowedValuesConstraint}.  
+ * Represents an individual enumerated value associated with an {@link IAllowedValuesConstraint}.
  */
 public interface IAllowedValue {
   /**

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/IAssemblyConstraintSupport.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/IAssemblyConstraintSupport.java
@@ -31,7 +31,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 /**
- * Represents a container of rules constraining the effective model of a Metaschema assembly data instance.
+ * Represents a container of rules constraining the effective model of a Metaschema assembly data
+ * instance.
  */
 public interface IAssemblyConstraintSupport extends IValueConstraintSupport {
   /**
@@ -57,7 +58,6 @@ public interface IAssemblyConstraintSupport extends IValueConstraintSupport {
    */
   @NotNull
   List<@NotNull ? extends ICardinalityConstraint> getHasCardinalityConstraints();
-
 
   void addConstraint(@NotNull IIndexConstraint constraint);
 

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/ICardinalityConstraint.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/ICardinalityConstraint.java
@@ -31,7 +31,8 @@ import gov.nist.secauto.metaschema.model.common.IModelInstance;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Represents a rule requiring a Metaschema assembly data instance to have elements with a minimum and/or maximum occurrence.
+ * Represents a rule requiring a Metaschema assembly data instance to have elements with a minimum
+ * and/or maximum occurrence.
  */
 public interface ICardinalityConstraint extends IConstraint {
   /**

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/IIndexConstraint.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/IIndexConstraint.java
@@ -29,9 +29,11 @@ package gov.nist.secauto.metaschema.model.common.constraint;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Represents a rule that generates a key-based index containing references to data items found in a Metaschema data instance.
+ * Represents a rule that generates a key-based index containing references to data items found in a
+ * Metaschema data instance.
  * <p>
- * The generated index can be used to check cross-references between Metaschema data objects using the {@link IIndexHasKeyConstraint}.
+ * The generated index can be used to check cross-references between Metaschema data objects using
+ * the {@link IIndexHasKeyConstraint}.
  */
 public interface IIndexConstraint extends IKeyConstraint {
   @NotNull

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/IScopedContraints.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/IScopedContraints.java
@@ -23,6 +23,7 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
+
 package gov.nist.secauto.metaschema.model.common.constraint;
 
 import org.jetbrains.annotations.NotNull;
@@ -33,8 +34,10 @@ import java.util.List;
 public interface IScopedContraints {
   @NotNull
   URI getMetaschemaNamespace();
+
   @NotNull
   String getMetaschemaShortName();
+
   @NotNull
   List<@NotNull ITargetedConstaints> getTargetedContraints();
 }

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/ITargetedConstaints.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/ITargetedConstaints.java
@@ -23,6 +23,7 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
+
 package gov.nist.secauto.metaschema.model.common.constraint;
 
 import gov.nist.secauto.metaschema.model.common.IAssemblyDefinition;

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/IUniqueConstraint.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/IUniqueConstraint.java
@@ -27,9 +27,11 @@
 package gov.nist.secauto.metaschema.model.common.constraint;
 
 /**
- * Represents a rule that requires all matching data items found in a Metaschema data instance to have a unique key.
+ * Represents a rule that requires all matching data items found in a Metaschema data instance to
+ * have a unique key.
  * <p>
- * This rule is similar to the {@link IIndexConstraint} in how the keys are generated, but this constraint type does not persist a named index.
+ * This rule is similar to the {@link IIndexConstraint} in how the keys are generated, but this
+ * constraint type does not persist a named index.
  */
 public interface IUniqueConstraint extends IKeyConstraint {
 

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/IValueConstraintSupport.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/IValueConstraintSupport.java
@@ -31,7 +31,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 /**
- * Represents a container of rules constraining the effective model of a Metaschema field or flag data instance.
+ * Represents a container of rules constraining the effective model of a Metaschema field or flag
+ * data instance.
  */
 public interface IValueConstraintSupport extends IConstraintSupport {
   /**

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/AbstractCustomJavaDataType.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/AbstractCustomJavaDataType.java
@@ -31,14 +31,16 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Objects;
 
 /**
- * A common base implementation of a custom Java object providing an underlying implementation of a data type.
+ * A common base implementation of a custom Java object providing an underlying implementation of a
+ * data type.
  * 
  * @param <TYPE>
  *          the bound object type supported by this data type
  * @param <VALUE>
  *          the inner value of the data type object
  */
-public abstract class AbstractCustomJavaDataType<TYPE extends ICustomJavaDataType<TYPE>, VALUE> implements ICustomJavaDataType<TYPE> {
+public abstract class AbstractCustomJavaDataType<TYPE extends ICustomJavaDataType<TYPE>, VALUE>
+    implements ICustomJavaDataType<TYPE> {
   @NotNull
   private final VALUE value;
 

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/AbstractDataTypeProvider.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/AbstractDataTypeProvider.java
@@ -36,10 +36,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A base implementation of an {@link IDataTypeProvider}, supporting dynamic loading of Metaschema data type
- * extensions at runtime.
+ * A base implementation of an {@link IDataTypeProvider}, supporting dynamic loading of Metaschema
+ * data type extensions at runtime.
  * <p>
- * The {@link MetaschemaDataTypeProvider} class provides an example of how to use this class to provide new data types.
+ * The {@link MetaschemaDataTypeProvider} class provides an example of how to use this class to
+ * provide new data types.
  */
 public abstract class AbstractDataTypeProvider implements IDataTypeProvider {
   private final Map<@NotNull String, IDataTypeAdapter<?>> library = new HashMap<>(); // NOPMD - synchronized

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/adapter/AbstractCustomJavaDataTypeAdapter.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/adapter/AbstractCustomJavaDataTypeAdapter.java
@@ -32,14 +32,16 @@ import gov.nist.secauto.metaschema.model.common.metapath.item.IAnyAtomicItem;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Provides a Java type adapter implementation for data types that are based on {@link ICustomJavaDataType}.
+ * Provides a Java type adapter implementation for data types that are based on
+ * {@link ICustomJavaDataType}.
  * 
  * @param <TYPE>
  *          the Java type this adapter supports, which is based on {@link ICustomJavaDataType}
  * @param <ITEM_TYPE>
  *          the Metapath item type associated with the adapter
  */
-public abstract class AbstractCustomJavaDataTypeAdapter<TYPE extends ICustomJavaDataType<TYPE>, ITEM_TYPE extends IAnyAtomicItem>
+public abstract class AbstractCustomJavaDataTypeAdapter<TYPE extends ICustomJavaDataType<
+    TYPE>, ITEM_TYPE extends IAnyAtomicItem>
     extends AbstractDataTypeAdapter<TYPE, ITEM_TYPE> {
 
   /**

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/markup/IMarkupText.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/markup/IMarkupText.java
@@ -71,7 +71,8 @@ public interface IMarkupText {
    * @throws XMLStreamException
    *           if an error occurred while writing
    */
-  void writeHtml(@NotNull OutputStream outputStream, @Nullable String namespace, @Nullable String prefix) throws XMLStreamException;
+  void writeHtml(@NotNull OutputStream outputStream, @Nullable String namespace, @Nullable String prefix)
+      throws XMLStreamException;
 
   @NotNull
   String toHtml();

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/markup/flexmark/InsertAnchorNode.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/markup/flexmark/InsertAnchorNode.java
@@ -63,7 +63,7 @@ public class InsertAnchorNode
   public void setIdReference(@NotNull BasedSequence value) {
     this.idReference = value;
   }
-  
+
   @Override
   @NotNull
   public BasedSequence[] getSegments() {

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/AbstractNAryExpression.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/AbstractNAryExpression.java
@@ -34,7 +34,8 @@ import java.util.Objects;
 /**
  * An immutable expression that has a number of sub-expression children.
  */
-abstract class AbstractNAryExpression extends AbstractExpression {
+abstract class AbstractNAryExpression
+    extends AbstractExpression {
   @NotNull
   private final List<@NotNull IExpression> children;
 

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/AbstractUnaryExpression.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/AbstractUnaryExpression.java
@@ -34,7 +34,8 @@ import java.util.Objects;
 /**
  * An immutable expression with a single sub-expression.
  */
-abstract class AbstractUnaryExpression extends AbstractExpression {
+abstract class AbstractUnaryExpression
+    extends AbstractExpression {
   @NotNull
   private final IExpression expr;
 

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/BuildAstVisitor.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/BuildAstVisitor.java
@@ -400,7 +400,7 @@ class BuildAstVisitor
       FunctioncallContext fcCtx = ctx.getChild(FunctioncallContext.class, idx + 1);
       String name = fcCtx.eqname().getText();
 
-      Stream<@NotNull IExpression> args  = parseArgumentList(fcCtx.argumentlist());
+      Stream<@NotNull IExpression> args = parseArgumentList(fcCtx.argumentlist());
       args = Stream.concat(Stream.of(left), args);
 
       return new FunctionCall(name, args.collect(Collectors.toUnmodifiableList()));

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/ContextItem.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/ContextItem.java
@@ -37,7 +37,7 @@ final class ContextItem
     extends AbstractPathExpression<INodeItem> {
   @NotNull
   private static final ContextItem SINGLETON = new ContextItem();
-  
+
   @NotNull
   public static ContextItem instance() {
     return SINGLETON;

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/Except.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/Except.java
@@ -24,7 +24,6 @@
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
 
-
 package gov.nist.secauto.metaschema.model.common.metapath;
 
 import gov.nist.secauto.metaschema.model.common.metapath.item.IItem;

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/IDocumentLoader.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/IDocumentLoader.java
@@ -44,7 +44,7 @@ import java.nio.file.Path;
 
 public interface IDocumentLoader extends IResourceLoader {
   void setEntityResolver(@NotNull EntityResolver resolver);
-  
+
   @NotNull
   default IDocumentNodeItem loadAsNodeItem(@NotNull URL url) throws IOException, URISyntaxException {
     return loadAsNodeItem(toInputSource(ObjectUtils.notNull(url.toURI())));
@@ -64,6 +64,7 @@ public interface IDocumentLoader extends IResourceLoader {
   default IDocumentNodeItem loadAsNodeItem(@NotNull InputStream is, @NotNull URI documentUri) throws IOException {
     InputSource source = toInputSource(documentUri);
     source.setByteStream(is);
+    // TODO: deal with charset?
     return loadAsNodeItem(source);
   }
 

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/IExpressionVisitor.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/IExpressionVisitor.java
@@ -23,6 +23,7 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
+
 package gov.nist.secauto.metaschema.model.common.metapath;
 
 import org.jetbrains.annotations.NotNull;
@@ -79,7 +80,7 @@ interface IExpressionVisitor<RESULT, CONTEXT> {
   RESULT visitNegate(@NotNull Negate expr, CONTEXT context);
 
   RESULT visitOr(@NotNull Or expr, CONTEXT context);
-  
+
   RESULT visitParentItem(@NotNull ParentItem parentContextItem, CONTEXT context);
 
   RESULT visitPredicate(@NotNull Predicate predicate, CONTEXT context);

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/INodeContext.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/INodeContext.java
@@ -23,6 +23,7 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
+
 package gov.nist.secauto.metaschema.model.common.metapath;
 
 import gov.nist.secauto.metaschema.model.common.metapath.item.IFlagNodeItem;

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/Intersect.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/Intersect.java
@@ -32,8 +32,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-class Intersect extends AbstractFilterExpression {
-  
+class Intersect
+    extends AbstractFilterExpression {
+
   protected Intersect(@NotNull IExpression left, @NotNull IExpression right) {
     super(left, right);
   }

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/ParentItem.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/ParentItem.java
@@ -37,7 +37,7 @@ final class ParentItem
     extends AbstractPathExpression<INodeItem> {
   @NotNull
   private static final ParentItem SINGLETON = new ParentItem();
-  
+
   @NotNull
   public static ParentItem instance() {
     return SINGLETON;

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/Step.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/Step.java
@@ -98,7 +98,6 @@ class Step implements IExpression { // NOPMD - intentional
     return stepExpression;
   }
 
-
   @Override
   public Class<@NotNull ? extends IItem> getStaticResultType() {
     return staticResultType;
@@ -152,7 +151,6 @@ class Step implements IExpression { // NOPMD - intentional
       return result.asStream();
     }));
   }
-  
 
   @SuppressWarnings("null")
   @Override

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/function/InvalidTypeFunctionException.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/function/InvalidTypeFunctionException.java
@@ -54,7 +54,7 @@ public class InvalidTypeFunctionException
   protected static String generateMessage(@NotNull IItem item) {
     String retval;
     if (item instanceof INodeItem) {
-      INodeItem nodeItem = (INodeItem)item;
+      INodeItem nodeItem = (INodeItem) item;
       retval = String.format("The %s node item at path '%s' has no typed value",
           nodeItem.getNodeItemType().name().toLowerCase(Locale.ROOT),
           nodeItem.getMetapath());
@@ -63,7 +63,7 @@ public class InvalidTypeFunctionException
     }
     return retval;
   }
-  
+
   @Override
   protected String getCodePrefix() {
     return "FOTY";

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/function/library/FnStartsWith.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/function/library/FnStartsWith.java
@@ -74,7 +74,7 @@ public final class FnStartsWith {
 
     return ISequence.of(fnStartsWith(arg1, arg2));
   }
-  
+
   private FnStartsWith() {
     // disable construction
   }

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/AbstractMetaschemaNodeItem.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/AbstractMetaschemaNodeItem.java
@@ -23,6 +23,7 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
+
 package gov.nist.secauto.metaschema.model.common.metapath.item;
 
 import gov.nist.secauto.metaschema.model.common.IMetaschema;
@@ -40,7 +41,6 @@ public abstract class AbstractMetaschemaNodeItem implements IMetaschemaNodeItem 
   private final IMetaschema metaschema;
   private Map<@NotNull String, IFlagNodeItem> flags;
   private Map<@NotNull String, ? extends List<@NotNull ? extends IModelNodeItem>> modelItems;
-
 
   public AbstractMetaschemaNodeItem(@NotNull IMetaschema metaschema) {
     this.metaschema = metaschema;
@@ -82,7 +82,6 @@ public abstract class AbstractMetaschemaNodeItem implements IMetaschemaNodeItem 
   public IFlagNodeItem getFlagByName(@NotNull String name) {
     return initFlags().get(name);
   }
-  
 
   protected Map<@NotNull String, ? extends List<@NotNull ? extends IModelNodeItem>> initModelItems() {
     synchronized (this) {

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/AbstractModelNodeItem.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/AbstractModelNodeItem.java
@@ -24,7 +24,6 @@
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
 
-
 package gov.nist.secauto.metaschema.model.common.metapath.item;
 
 import org.jetbrains.annotations.NotNull;

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/AssemblyInstanceNodeItemImpl.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/AssemblyInstanceNodeItemImpl.java
@@ -62,7 +62,7 @@ class AssemblyInstanceNodeItemImpl
   public IAssemblyNodeItem getParentContentNodeItem() {
     return getParentNodeItem();
   }
-  
+
   @Override
   public Object getValue() {
     // there is no value

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IAssemblyNodeItem.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IAssemblyNodeItem.java
@@ -49,7 +49,7 @@ public interface IAssemblyNodeItem extends IModelNodeItem {
   @Override
   default IAssemblyNodeItem getParentContentNodeItem() {
     INodeItem parent = getParentNodeItem();
-    return parent instanceof IAssemblyNodeItem ? (IAssemblyNodeItem)parent : null;
+    return parent instanceof IAssemblyNodeItem ? (IAssemblyNodeItem) parent : null;
   }
 
   @Override

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IBooleanItem.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IBooleanItem.java
@@ -55,7 +55,7 @@ public interface IBooleanItem extends IAnyAtomicItem {
     } else {
       try {
         Boolean bool = MetaschemaDataTypeProvider.BOOLEAN.parse(value);
-        retval =  valueOf(bool);
+        retval = valueOf(bool);
       } catch (IllegalArgumentException ex) {
         throw new InvalidValueForCastFunctionException(String.format("Unable to parse string value '%s'", value),
             ex);

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IDefinitionNodeItem.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IDefinitionNodeItem.java
@@ -23,6 +23,7 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
+
 package gov.nist.secauto.metaschema.model.common.metapath.item;
 
 import gov.nist.secauto.metaschema.model.common.INamedDefinition;

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IDocumentNodeItem.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IDocumentNodeItem.java
@@ -55,7 +55,6 @@ public interface IDocumentNodeItem extends IRequiredValueNodeItem {
   @NotNull
   IRootAssemblyNodeItem getRootAssemblyNodeItem();
 
-
   @Override
   default IRequiredValueModelNodeItem getParentContentNodeItem() {
     // there is no parent
@@ -116,6 +115,7 @@ public interface IDocumentNodeItem extends IRequiredValueNodeItem {
   default Stream<@NotNull ? extends IModelNodeItem> modelItems() {
     return Stream.of(getRootAssemblyNodeItem());
   }
+
   @SuppressWarnings("null")
   @Override
   default @NotNull List<@NotNull ? extends IRequiredValueModelNodeItem> getModelItemsByName(String name) {

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IMetaschemaNodeItem.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IMetaschemaNodeItem.java
@@ -23,6 +23,7 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
+
 package gov.nist.secauto.metaschema.model.common.metapath.item;
 
 import gov.nist.secauto.metaschema.model.common.metapath.format.IPathFormatter;

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/INodeItemFactory.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/INodeItemFactory.java
@@ -42,7 +42,7 @@ import org.jetbrains.annotations.Nullable;
 import java.net.URI;
 
 public interface INodeItemFactory {
-  
+
   @SuppressWarnings("null")
   @NotNull
   default INodeItem newNodeItem(@NotNull INamedDefinition definition, @NotNull Object value, @NotNull URI baseUri,
@@ -115,7 +115,7 @@ public interface INodeItemFactory {
 
   default IAssemblyNodeItem newAssemblyNodeItem(@NotNull IAssemblyDefinition definition, @NotNull Object value,
       @Nullable URI baseUri) {
-      return new RequiredValueAssemblyDefinitionNodeItemImpl(definition, value, baseUri);
+    return new RequiredValueAssemblyDefinitionNodeItemImpl(definition, value, baseUri);
   }
 
   @NotNull

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/INodeItemVisitable.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/INodeItemVisitable.java
@@ -23,6 +23,7 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
+
 package gov.nist.secauto.metaschema.model.common.metapath.item;
 
 import org.jetbrains.annotations.NotNull;

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/INodeItemVisitor.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/INodeItemVisitor.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.NotNull;
 
 public interface INodeItemVisitor<RESULT, CONTEXT> {
   RESULT visitDocument(@NotNull IDocumentNodeItem item, CONTEXT context);
-  
+
   RESULT visitFlag(@NotNull IFlagNodeItem item, CONTEXT context);
 
   RESULT visitField(@NotNull IFieldNodeItem item, CONTEXT context);

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IRequiredValueDefinitionNodeItem.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IRequiredValueDefinitionNodeItem.java
@@ -23,6 +23,7 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
+
 package gov.nist.secauto.metaschema.model.common.metapath.item;
 
 public interface IRequiredValueDefinitionNodeItem extends IRequiredValueNodeItem, IDefinitionNodeItem {

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IRequiredValueModelNodeItem.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IRequiredValueModelNodeItem.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
  * This marker interface indicates that the {@link IModelNodeItem} must have a value to exist.
  */
 public interface IRequiredValueModelNodeItem extends IModelNodeItem, IRequiredValueDefinitionNodeItem {
-  
+
   @Override
   IRequiredValueNodeItem getParentNodeItem();
 

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IRequiredValueNodeItem.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IRequiredValueNodeItem.java
@@ -37,7 +37,7 @@ public interface IRequiredValueNodeItem extends INodeItem {
 
   @Override
   IRequiredValueNodeItem getParentNodeItem();
-  
+
   @Override
   IRequiredValueModelNodeItem getParentContentNodeItem();
 

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IRootAssemblyNodeItem.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/IRootAssemblyNodeItem.java
@@ -41,7 +41,7 @@ public interface IRootAssemblyNodeItem extends IRequiredValueAssemblyNodeItem {
 
   @NotNull
   IDocumentNodeItem getDocumentNodeItem();
-  
+
   @Override
   @NotNull
   default IDocumentNodeItem getParentNodeItem() {

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/MetaschemaNodeItemImpl.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/MetaschemaNodeItemImpl.java
@@ -23,6 +23,7 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
+
 package gov.nist.secauto.metaschema.model.common.metapath.item;
 
 import gov.nist.secauto.metaschema.model.common.IFlagDefinition;
@@ -38,7 +39,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-class MetaschemaNodeItemImpl extends AbstractMetaschemaNodeItem {
+class MetaschemaNodeItemImpl
+    extends AbstractMetaschemaNodeItem {
 
   public MetaschemaNodeItemImpl(@NotNull IMetaschema metaschema) {
     super(metaschema);
@@ -51,7 +53,7 @@ class MetaschemaNodeItemImpl extends AbstractMetaschemaNodeItem {
             Collectors.toMap(
                 IFlagDefinition::getEffectiveName,
                 def -> ModelFactoryImpl.instance().newFlagNodeItem(def, getBaseUri()),
-                (v1,v2) -> v2,
+                (v1, v2) -> v2,
                 LinkedHashMap::new)));
   }
 
@@ -59,10 +61,10 @@ class MetaschemaNodeItemImpl extends AbstractMetaschemaNodeItem {
   @Override
   protected Map<@NotNull String, List<@NotNull IModelNodeItem>> newModelItems() {
     Stream<@NotNull IFieldNodeItem> fieldStream = getMetaschema().getFieldDefinitions().stream()
-      .map(def -> ModelFactoryImpl.instance().newFieldNodeItem(def, getBaseUri()));
+        .map(def -> ModelFactoryImpl.instance().newFieldNodeItem(def, getBaseUri()));
     Stream<@NotNull IAssemblyNodeItem> assemblyStream = getMetaschema().getAssemblyDefinitions().stream()
         .map(def -> ModelFactoryImpl.instance().newAssemblyNodeItem(def, getBaseUri()));
-    
+
     return CollectionUtil.unmodifiableMap(Stream.concat(fieldStream, assemblyStream)
         .collect(
             Collectors.collectingAndThen(

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/RootAssemblyValuedNodeItemImpl.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/RootAssemblyValuedNodeItemImpl.java
@@ -69,7 +69,7 @@ class RootAssemblyValuedNodeItemImpl
   public IDocumentNodeItem getDocumentNodeItem() {
     return parent;
   }
-  
+
   @Override
   public IRequiredValueAssemblyNodeItem getParentContentNodeItem() {
     // there is no parent assembly

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/util/CustomCollectors.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/util/CustomCollectors.java
@@ -65,7 +65,6 @@ public final class CustomCollectors {
           list.get(last));
     };
   }
-  
 
   /**
    * Produce a new stream with duplicates removed based on the provided {@code keyMapper}. When a
@@ -101,7 +100,8 @@ public final class CustomCollectors {
    *          the stream to reduce
    * @param keyMapper
    *          the key function to use to find unique items
-   * @param duplicateHander used to determine which of two duplicates to keep
+   * @param duplicateHander
+   *          used to determine which of two duplicates to keep
    * @return a new stream
    */
   public static <V, K> Stream<V> distinctByKey(
@@ -128,8 +128,7 @@ public final class CustomCollectors {
       @NotNull Function<? super T, ? extends K> keyMapper,
       @NotNull Function<? super T, ? extends V> valueMapper,
       @NotNull DuplicateHandler<K, V> duplicateHander,
-      Supplier<M> supplier
-      ) {
+      Supplier<M> supplier) {
     return Collector.of(
         supplier,
         (map, item) -> {

--- a/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/AndTest.java
+++ b/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/AndTest.java
@@ -23,6 +23,7 @@
  * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
+
 package gov.nist.secauto.metaschema.model.common.metapath;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,8 +38,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.List;
 import java.util.stream.Stream;
 
-class AndTest extends AbstractExpressionTest {
-  
+class AndTest
+    extends AbstractExpressionTest {
+
   private static Stream<Arguments> testAnd() {
     return Stream.of(
         Arguments.of(IBooleanItem.TRUE, IBooleanItem.TRUE, IBooleanItem.TRUE),

--- a/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/BuildAstVisitorTest.java
+++ b/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/BuildAstVisitorTest.java
@@ -87,8 +87,8 @@ class BuildAstVisitorTest {
     parser.addErrorListener(new FailingErrorListener());
 
     ParseTree tree = parser.expr();
-//    CSTPrinter cstPrinter = new CSTPrinter(System.out);
-//    cstPrinter.print(tree, Arrays.asList(parser.getRuleNames()));
+    // CSTPrinter cstPrinter = new CSTPrinter(System.out);
+    // cstPrinter.print(tree, Arrays.asList(parser.getRuleNames()));
 
     return new BuildAstVisitor().visit(tree);
   }

--- a/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/FlagTest.java
+++ b/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/FlagTest.java
@@ -36,7 +36,8 @@ import gov.nist.secauto.metaschema.model.common.metapath.item.NodeItemType;
 import org.jmock.Expectations;
 import org.junit.jupiter.api.Test;
 
-class FlagTest extends AbstractExpressionTest {
+class FlagTest
+    extends AbstractExpressionTest {
   @Test
   void testFlagWithName() {
     DynamicContext dynamicContext = newDynamicContext();

--- a/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/OrTest.java
+++ b/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/OrTest.java
@@ -38,8 +38,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.List;
 import java.util.stream.Stream;
 
-class OrTest extends AbstractExpressionTest {
-  
+class OrTest
+    extends AbstractExpressionTest {
+
   private static Stream<Arguments> testOr() {
     return Stream.of(
         Arguments.of(IBooleanItem.TRUE, IBooleanItem.TRUE, IBooleanItem.TRUE),

--- a/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/RootSlashOnlyTest.java
+++ b/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/RootSlashOnlyTest.java
@@ -33,8 +33,9 @@ import gov.nist.secauto.metaschema.model.common.metapath.item.INodeItem;
 
 import org.junit.jupiter.api.Test;
 
-class RootSlashOnlyTest extends AbstractExpressionTest {
-  
+class RootSlashOnlyTest
+    extends AbstractExpressionTest {
+
   @Test
   void testRootSlashOnlyPathUsingDocument() {
     DynamicContext dynamicContext = newDynamicContext();

--- a/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/item/IBase64BinaryItemTest.java
+++ b/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/item/IBase64BinaryItemTest.java
@@ -47,14 +47,16 @@ class IBase64BinaryItemTest {
 
   @Test
   void testCastSame() {
-    ByteBuffer buf = ObjectUtils.notNull(ByteBuffer.allocate(16).putLong(-9223372036854775808L).putLong(9223372036854775807L));
+    ByteBuffer buf
+        = ObjectUtils.notNull(ByteBuffer.allocate(16).putLong(-9223372036854775808L).putLong(9223372036854775807L));
     IBase64BinaryItem item = IBase64BinaryItem.valueOf(buf);
     assertEquals(IBase64BinaryItem.cast(item), item);
   }
 
   @Test
   void testCastString() {
-    ByteBuffer buf = ObjectUtils.notNull(ByteBuffer.allocate(16).putLong(-9223372036854775808L).putLong(9223372036854775807L));
+    ByteBuffer buf
+        = ObjectUtils.notNull(ByteBuffer.allocate(16).putLong(-9223372036854775808L).putLong(9223372036854775807L));
     IBase64BinaryItem expected = IBase64BinaryItem.valueOf(buf);
     IBase64BinaryItem actual = IBase64BinaryItem.cast(IStringItem.valueOf("gAAAAAAAAAB//////////w=="));
     Assertions.assertAll(

--- a/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/item/IBooleanItemTest.java
+++ b/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/item/IBooleanItemTest.java
@@ -52,11 +52,10 @@ public class IBooleanItemTest {
         () -> assertEquals(IBooleanItem.valueOf(ObjectUtils.notNull(Boolean.FALSE)), IBooleanItem.FALSE),
         () -> assertEquals(IBooleanItem.valueOf("1"), IBooleanItem.TRUE, "1"),
         () -> assertEquals(IBooleanItem.valueOf("0"), IBooleanItem.FALSE, "0"),
-        () -> assertEquals(IBooleanItem.valueOf(""), IBooleanItem.FALSE,""),
+        () -> assertEquals(IBooleanItem.valueOf(""), IBooleanItem.FALSE, ""),
         () -> assertEquals(IBooleanItem.valueOf("true"), IBooleanItem.TRUE),
         () -> assertEquals(IBooleanItem.valueOf("false"), IBooleanItem.FALSE));
   }
-  
 
   private static Stream<Arguments> provideValuesForCast() {
     return Stream.of(
@@ -80,5 +79,5 @@ public class IBooleanItemTest {
     IBooleanItem result = IBooleanItem.cast(item);
     assertEquals(expected, result);
   }
-   
+
 }

--- a/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/item/INumericItemTest.java
+++ b/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/item/INumericItemTest.java
@@ -137,7 +137,6 @@ class INumericItemTest {
     assertEquals(expected, result);
   }
 
-
   private static Stream<Arguments> provideValuesForCastFail() {
     return Stream.of(
         Arguments.of(string("x123")),

--- a/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/item/MockItemFactory.java
+++ b/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/metapath/item/MockItemFactory.java
@@ -118,7 +118,7 @@ public class MockItemFactory {
           allowing(flag).getParentNodeItem();
           will(returnValue(item));
         });
-        
+
         Map<@NotNull String, List<IModelNodeItem>> modelItemsMap = toModelItemsMap(modelItems);
         allowing(item).getModelItems();
         will(returnValue(modelItemsMap.values()));

--- a/metaschema-model/src/main/java/gov/nist/secauto/metaschema/model/AssemblyTargetedConstraints.java
+++ b/metaschema-model/src/main/java/gov/nist/secauto/metaschema/model/AssemblyTargetedConstraints.java
@@ -43,22 +43,23 @@ class AssemblyTargetedConstraints
     extends AbstractTargetedConstraints<AssemblyConstraintSupport>
     implements IAssemblyConstraintSupport {
 
-  public AssemblyTargetedConstraints(@NotNull MetapathExpression targetExpression, @NotNull AssemblyConstraintSupport constraints) {
+  public AssemblyTargetedConstraints(@NotNull MetapathExpression targetExpression,
+      @NotNull AssemblyConstraintSupport constraints) {
     super(targetExpression, constraints);
   }
 
   @Override
-  public  List<@NotNull ? extends IIndexConstraint> getIndexConstraints() {
+  public List<@NotNull ? extends IIndexConstraint> getIndexConstraints() {
     return getConstraintSupport().getIndexConstraints();
   }
 
   @Override
-  public  List<@NotNull ? extends IUniqueConstraint> getUniqueConstraints() {
+  public List<@NotNull ? extends IUniqueConstraint> getUniqueConstraints() {
     return getConstraintSupport().getUniqueConstraints();
   }
 
   @Override
-  public  List<@NotNull ? extends ICardinalityConstraint> getHasCardinalityConstraints() {
+  public List<@NotNull ? extends ICardinalityConstraint> getHasCardinalityConstraints() {
     return getConstraintSupport().getHasCardinalityConstraints();
   }
 
@@ -76,10 +77,10 @@ class AssemblyTargetedConstraints
   public void addConstraint(@NotNull ICardinalityConstraint constraint) {
     getConstraintSupport().addConstraint(constraint);
   }
-  
+
   @Override
   public void target(@NotNull IAssemblyDefinition definition) {
-    applyTo((INamedDefinition)definition);
+    applyTo((INamedDefinition) definition);
     applyTo(definition);
   }
 

--- a/metaschema-model/src/main/java/gov/nist/secauto/metaschema/model/xmlbeans/handler/ConstraintExtensionEnum.java
+++ b/metaschema-model/src/main/java/gov/nist/secauto/metaschema/model/xmlbeans/handler/ConstraintExtensionEnum.java
@@ -41,7 +41,8 @@ public final class ConstraintExtensionEnum {
    * @param target
    *          the XML value to cast to a boolean
    */
-  public static void encodeExtensibleEnumType(IAllowedValuesConstraint.Extensible obj, org.apache.xmlbeans.SimpleValue target) {
+  public static void encodeExtensibleEnumType(IAllowedValuesConstraint.Extensible obj,
+      org.apache.xmlbeans.SimpleValue target) {
     if (obj != null) {
       switch (obj) {
       case NONE:

--- a/metaschema-model/src/test/java/gov/nist/secauto/metaschema/model/MetaschemaLoaderTest.java
+++ b/metaschema-model/src/test/java/gov/nist/secauto/metaschema/model/MetaschemaLoaderTest.java
@@ -73,7 +73,7 @@ class MetaschemaLoaderTest {
         = loader.load(metaschemaUri);
     assertFalse(metaschema.getRootAssemblyDefinitions().isEmpty(), "no roots found");
   }
-  
+
   @Test
   void testConstraints() throws MetaschemaException, IOException { // NOPMD - intentional
     ConstraintLoader constraintLoader = new ConstraintLoader();

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/AbstractDatatypeManager.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/AbstractDatatypeManager.java
@@ -73,7 +73,8 @@ public abstract class AbstractDatatypeManager implements IDatatypeManager {
   }
 
   @NotNull
-  private final Map<gov.nist.secauto.metaschema.model.common.datatype.adapter.IDataTypeAdapter<?>, String> datatypeToTypeMap = new HashMap<>();
+  private final Map<gov.nist.secauto.metaschema.model.common.datatype.adapter.IDataTypeAdapter<?>,
+      String> datatypeToTypeMap = new HashMap<>();
   @NotNull
   private final Map<INamedDefinition, String> definitionToNameMap
       = new HashMap<>();

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/AbstractXmlMarkupDatatypeProvider.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/AbstractXmlMarkupDatatypeProvider.java
@@ -39,7 +39,6 @@ import java.util.stream.Collectors;
 public abstract class AbstractXmlMarkupDatatypeProvider
     extends AbstractXmlDatatypeProvider {
 
-
   @Override
   protected InputStream getSchemaResource() {
     return JDom2XmlSchemaLoader.class.getClassLoader()
@@ -48,7 +47,7 @@ public abstract class AbstractXmlMarkupDatatypeProvider
 
   @NotNull
   protected abstract String getSchemaResourcePath();
-  
+
   @Override
   protected List<@NotNull Element> queryElements(JDom2XmlSchemaLoader loader) {
     return loader.getContent(


### PR DESCRIPTION
# Committer Notes

Fixed a bug causing the UTF8 encoding to not be used when serializing to an input stream.
Also adjusted YAML output to reduce the amount of quoted strings and to avoid line folding where possible.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
