### PR TITLE
Fix allowed values behavior during validation

### DIFF
--- a/metaschema-freemarker-support/pom.xml
+++ b/metaschema-freemarker-support/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.8.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metaschema-freemarker-support</artifactId>

--- a/metaschema-java-binding/pom.xml
+++ b/metaschema-java-binding/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.8.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metaschema-java-binding</artifactId>

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/DefaultBindingContext.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/DefaultBindingContext.java
@@ -260,7 +260,7 @@ public class DefaultBindingContext implements IBindingContext {
     context.setDocumentLoader(newBoundLoader());
     FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
     DefaultConstraintValidator validator = new DefaultConstraintValidator(context, handler);
-    validator.visit(nodeItem);
+    validator.validate(nodeItem);
     return handler;
   }
 

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/AbstractDeserializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/AbstractDeserializer.java
@@ -101,7 +101,7 @@ public abstract class AbstractDeserializer<CLASS>
       DefaultConstraintValidator validator = new DefaultConstraintValidator(
           dynamicContext,
           getConstraintValidationHandler());
-      validator.visit(nodeItem);
+      validator.validate(nodeItem);
       validator.finalizeValidation();
     }
     return nodeItem;

--- a/metaschema-java-codegen/pom.xml
+++ b/metaschema-java-codegen/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.8.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metaschema-java-codegen</artifactId>

--- a/metaschema-maven-plugin/pom.xml
+++ b/metaschema-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.8.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metaschema-maven-plugin</artifactId>

--- a/metaschema-model-common/pom.xml
+++ b/metaschema-model-common/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.8.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metaschema-model-common</artifactId>

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/IConstraintValidator.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/constraint/IConstraintValidator.java
@@ -27,9 +27,7 @@
 package gov.nist.secauto.metaschema.model.common.constraint;
 
 import gov.nist.secauto.metaschema.model.common.metapath.MetapathException;
-import gov.nist.secauto.metaschema.model.common.metapath.item.IAssemblyNodeItem;
-import gov.nist.secauto.metaschema.model.common.metapath.item.IFieldNodeItem;
-import gov.nist.secauto.metaschema.model.common.metapath.item.IFlagNodeItem;
+import gov.nist.secauto.metaschema.model.common.metapath.item.INodeItem;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -39,34 +37,14 @@ import org.jetbrains.annotations.NotNull;
  */
 public interface IConstraintValidator {
   /**
-   * Validate the provided flag item against any associated constraints.
+   * Validate the provided item against any associated constraints.
    * 
    * @param item
-   *          the flag item to validate
+   *          the item to validate
    * @throws MetapathException
    *           if an error occurred while evaluating a Metapath used in a constraint
    */
-  void validate(@NotNull IFlagNodeItem item);
-
-  /**
-   * Validate the provided field item against any associated constraints.
-   * 
-   * @param item
-   *          the field item to validate
-   * @throws MetapathException
-   *           if an error occurred while evaluating a Metapath used in a constraint
-   */
-  void validate(@NotNull IFieldNodeItem item);
-
-  /**
-   * Validate the provided assembly item against any associated constraints.
-   * 
-   * @param item
-   *          the assembly item to validate
-   * @throws MetapathException
-   *           if an error occurred while evaluating a Metapath used in a constraint
-   */
-  void validate(@NotNull IAssemblyNodeItem item);
+  void validate(@NotNull INodeItem item);
 
   /**
    * Complete any validations that require full analysis of the content model.

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/IDocumentLoader.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/IDocumentLoader.java
@@ -70,5 +70,4 @@ public interface IDocumentLoader extends IResourceLoader {
 
   @NotNull
   IDocumentNodeItem loadAsNodeItem(@NotNull InputSource source) throws IOException;
-
 }

--- a/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/constraint/DefaultConstraintValidatorTest.java
+++ b/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/constraint/DefaultConstraintValidatorTest.java
@@ -1,0 +1,261 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.model.common.constraint;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.nist.secauto.metaschema.model.common.IFlagDefinition;
+import gov.nist.secauto.metaschema.model.common.constraint.IAllowedValuesConstraint.Extensible;
+import gov.nist.secauto.metaschema.model.common.constraint.IConstraint.InternalModelSource;
+import gov.nist.secauto.metaschema.model.common.constraint.IConstraint.Level;
+import gov.nist.secauto.metaschema.model.common.datatype.markup.MarkupLine;
+import gov.nist.secauto.metaschema.model.common.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.model.common.metapath.MetapathExpression;
+import gov.nist.secauto.metaschema.model.common.metapath.StaticContext;
+import gov.nist.secauto.metaschema.model.common.metapath.format.IPathFormatter;
+import gov.nist.secauto.metaschema.model.common.metapath.item.IFlagNodeItem;
+import gov.nist.secauto.metaschema.model.common.metapath.item.IStringItem;
+import gov.nist.secauto.metaschema.model.common.metapath.item.MockItemFactory;
+import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
+
+import org.jetbrains.annotations.NotNull;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.api.Invocation;
+import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.lib.action.CustomAction;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.List;
+
+class DefaultConstraintValidatorTest {
+  @RegisterExtension
+  Mockery context = new JUnit5Mockery();
+
+  @Test
+  void testAllowedValuesAllowOther() {
+    MockItemFactory itemFactory = new MockItemFactory(context);
+
+    IFlagNodeItem flag = itemFactory.flag("value", IStringItem.valueOf("value"));
+
+    IFlagDefinition flagDefinition = context.mock(IFlagDefinition.class);
+
+    DefaultAllowedValuesConstraint allowedValues = new DefaultAllowedValuesConstraint(
+        null,
+        InternalModelSource.instance(),
+        Level.ERROR,
+        MetapathExpression.CONTEXT_NODE,
+        CollectionUtil.singletonMap("other",
+            new DefaultAllowedValue("other", MarkupLine.fromMarkdown("some documentation"))),
+        true,
+        Extensible.MODEL,
+        null);
+
+    context.checking(new Expectations() {
+      { // NOPMD - intentional
+        allowing(flag).getDefinition();
+        will(returnValue(flagDefinition));
+        allowing(flag).accept(with(any(DefaultConstraintValidator.Visitor.class)), with(aNull(Void.class)));
+        will(new FlagVisitorAction());
+        allowing(flag).toPath(with(any(IPathFormatter.class)));
+        will(returnValue("flag/path"));
+
+        allowing(flagDefinition).getAllowedValuesConstraints();
+        will(returnValue(CollectionUtil.singletonList(allowedValues)));
+        allowing(flagDefinition).getExpectConstraints();
+        will(returnValue(CollectionUtil.emptyList()));
+        allowing(flagDefinition).getMatchesConstraints();
+        will(returnValue(CollectionUtil.emptyList()));
+        allowing(flagDefinition).getIndexHasKeyConstraints();
+        will(returnValue(CollectionUtil.emptyList()));
+      }
+    });
+
+    DynamicContext dynamicContext = new StaticContext().newDynamicContext();
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(dynamicContext, handler);
+    validator.validate(flag);
+    validator.finalizeValidation();
+
+    assertTrue(handler.isPassing());
+  }
+
+  @Test
+  void testAllowedValuesMultipleAllowOther() {
+    MockItemFactory itemFactory = new MockItemFactory(context);
+
+    IFlagNodeItem flag = itemFactory.flag("value", IStringItem.valueOf("value"));
+
+    IFlagDefinition flagDefinition = context.mock(IFlagDefinition.class);
+
+    DefaultAllowedValuesConstraint allowedValues1 = new DefaultAllowedValuesConstraint(
+        null,
+        InternalModelSource.instance(),
+        Level.ERROR,
+        MetapathExpression.CONTEXT_NODE,
+        CollectionUtil.singletonMap("other",
+            new DefaultAllowedValue("other", MarkupLine.fromMarkdown("some documentation"))),
+        true,
+        Extensible.MODEL,
+        null);
+    DefaultAllowedValuesConstraint allowedValues2 = new DefaultAllowedValuesConstraint(
+        null,
+        InternalModelSource.instance(),
+        Level.ERROR,
+        MetapathExpression.CONTEXT_NODE,
+        CollectionUtil.singletonMap("other2",
+            new DefaultAllowedValue("other2", MarkupLine.fromMarkdown("some documentation"))),
+        true,
+        Extensible.MODEL,
+        null);
+
+    List<@NotNull ? extends IAllowedValuesConstraint> allowedValuesConstraints
+        = List.of(allowedValues1, allowedValues2);
+
+    context.checking(new Expectations() {
+      { // NOPMD - intentional
+        allowing(flag).getDefinition();
+        will(returnValue(flagDefinition));
+        allowing(flag).accept(with(any(DefaultConstraintValidator.Visitor.class)), with(aNull(Void.class)));
+        will(new FlagVisitorAction());
+        allowing(flag).toPath(with(any(IPathFormatter.class)));
+        will(returnValue("flag/path"));
+
+        allowing(flagDefinition).getAllowedValuesConstraints();
+        will(returnValue(allowedValuesConstraints));
+        allowing(flagDefinition).getExpectConstraints();
+        will(returnValue(CollectionUtil.emptyList()));
+        allowing(flagDefinition).getMatchesConstraints();
+        will(returnValue(CollectionUtil.emptyList()));
+        allowing(flagDefinition).getIndexHasKeyConstraints();
+        will(returnValue(CollectionUtil.emptyList()));
+      }
+    });
+
+    DynamicContext dynamicContext = new StaticContext().newDynamicContext();
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(dynamicContext, handler);
+    validator.validate(flag);
+    validator.finalizeValidation();
+
+    assertTrue(handler.isPassing());
+  }
+
+  @Test
+  void testMultipleAllowedValuesConflictingAllowOther() {
+    MockItemFactory itemFactory = new MockItemFactory(context);
+
+    IFlagNodeItem flag1 = itemFactory.flag("value", IStringItem.valueOf("value"));
+    IFlagNodeItem flag2 = itemFactory.flag("other2", IStringItem.valueOf("other2"));
+
+    IFlagDefinition flagDefinition = context.mock(IFlagDefinition.class);
+
+    DefaultAllowedValuesConstraint allowedValues1 = new DefaultAllowedValuesConstraint(
+        null,
+        InternalModelSource.instance(),
+        Level.ERROR,
+        MetapathExpression.CONTEXT_NODE,
+        CollectionUtil.singletonMap("other",
+            new DefaultAllowedValue("other", MarkupLine.fromMarkdown("some documentation"))),
+        true,
+        Extensible.MODEL,
+        null);
+    DefaultAllowedValuesConstraint allowedValues2 = new DefaultAllowedValuesConstraint(
+        null,
+        InternalModelSource.instance(),
+        Level.ERROR,
+        MetapathExpression.CONTEXT_NODE,
+        CollectionUtil.singletonMap("other2",
+            new DefaultAllowedValue("other2", MarkupLine.fromMarkdown("some documentation"))),
+        false,
+        Extensible.MODEL,
+        null);
+
+    List<@NotNull ? extends IAllowedValuesConstraint> allowedValuesConstraints
+        = List.of(allowedValues1, allowedValues2);
+
+    context.checking(new Expectations() {
+      { // NOPMD - intentional
+        allowing(flag1).getDefinition();
+        will(returnValue(flagDefinition));
+        allowing(flag1).accept(with(any(DefaultConstraintValidator.Visitor.class)), with(aNull(Void.class)));
+        will(new FlagVisitorAction());
+        allowing(flag1).toPath(with(any(IPathFormatter.class)));
+        will(returnValue("flag1/path"));
+
+        allowing(flag2).getDefinition();
+        will(returnValue(flagDefinition));
+        allowing(flag2).accept(with(any(DefaultConstraintValidator.Visitor.class)), with(aNull(Void.class)));
+        will(new FlagVisitorAction());
+        allowing(flag2).toPath(with(any(IPathFormatter.class)));
+        will(returnValue("flag2/path"));
+
+        allowing(flagDefinition).getAllowedValuesConstraints();
+        will(returnValue(allowedValuesConstraints));
+        allowing(flagDefinition).getExpectConstraints();
+        will(returnValue(CollectionUtil.emptyList()));
+        allowing(flagDefinition).getMatchesConstraints();
+        will(returnValue(CollectionUtil.emptyList()));
+        allowing(flagDefinition).getIndexHasKeyConstraints();
+        will(returnValue(CollectionUtil.emptyList()));
+      }
+    });
+
+    DynamicContext dynamicContext = new StaticContext().newDynamicContext();
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(dynamicContext, handler);
+    validator.validate(flag1);
+    validator.validate(flag2);
+    validator.finalizeValidation();
+    assertAll(
+        () -> assertTrue(!handler.isPassing()),
+        () -> assertThat(handler.getFindings(), hasSize(1)),
+        () -> assertThat(handler.getFindings(), hasItem(hasProperty("node", is(flag1)))));
+  }
+
+  private class FlagVisitorAction
+      extends CustomAction {
+
+    public FlagVisitorAction() {
+      super("return the flag");
+    }
+
+    @Override
+    public Object invoke(Invocation invocation) throws Throwable {
+      IFlagNodeItem thisFlag = (IFlagNodeItem) invocation.getInvokedObject();
+      DefaultConstraintValidator.Visitor visitor = (DefaultConstraintValidator.Visitor) invocation.getParameter(0);
+      return visitor.visitFlag(thisFlag, null);
+    }
+  }
+}

--- a/metaschema-model/pom.xml
+++ b/metaschema-model/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.8.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metaschema-model</artifactId>

--- a/metaschema-schema-generator/pom.xml
+++ b/metaschema-schema-generator/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.8.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metaschema-schema-generator</artifactId>

--- a/metaschema-testing/pom.xml
+++ b/metaschema-testing/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>gov.nist.secauto.metaschema</groupId>
 		<artifactId>metaschema-framework</artifactId>
-		<version>0.8.2-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>metaschema-testing</artifactId>
 	<name>Metaschema Unit Testing Support</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<groupId>gov.nist.secauto.metaschema</groupId>
 	<artifactId>metaschema-framework</artifactId>
-	<version>0.8.2-SNAPSHOT</version>
+	<version>0.9.0-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
# Committer Notes

- Refactored IConstraintValidator API to avoid misuse by calling the previous validate methods directly, instead of the visitor method.
- Fixed allowed values validation logic preventing constraint sets allowing other values to fail. Fixes usnistgov/metaschema-java#76.

closes usnistgov/metaschema-java#76

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
