### PR TITLE
Configured IP address support to allow leading zeros. 

### DIFF
--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/adapter/IPv6AddressAdapter.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/adapter/IPv6AddressAdapter.java
@@ -49,9 +49,17 @@ public class IPv6AddressAdapter
   private static final IPAddressStringParameters IP_V_6;
 
   static {
-    IP_V_6 = new IPAddressStringParameters.Builder().allowIPv4(false).allowEmpty(false).allowSingleSegment(false)
-        .allowWildcardedSeparator(false).getIPv6AddressParametersBuilder().allowBinary(false).allowLeadingZeros(false)
-        .allowPrefixesBeyondAddressSize(false).getParentBuilder().toParams();
+    IP_V_6 = new IPAddressStringParameters.Builder()
+        .allowIPv4(false)
+        .allowEmpty(false)
+        .allowSingleSegment(false)
+        .allowWildcardedSeparator(false)
+        .getIPv6AddressParametersBuilder()
+        .allowBinary(false)
+        .allowLeadingZeros(true)
+        .allowPrefixesBeyondAddressSize(false)
+        .getParentBuilder()
+        .toParams();
   }
 
   IPv6AddressAdapter() {

--- a/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/datatype/adapter/IPv6AddressAdapterTest.java
+++ b/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/datatype/adapter/IPv6AddressAdapterTest.java
@@ -1,0 +1,14 @@
+package gov.nist.secauto.metaschema.model.common.datatype.adapter;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class IPv6AddressAdapterTest {
+
+
+  @ParameterizedTest
+  @ValueSource(strings = { "2001:0000:0000:0000:0000:ffff:0a02:0202" })
+  void testValues(String value) {
+    new IPv6AddressAdapter().parse(value);
+  }
+}


### PR DESCRIPTION
# Committer Notes

Resolved a bug causing IPv6 addresses with leading zeros (i.e., `2001:0000:0000:0000:0000:ffff:0a02:0202`) to be invalid causing an IllegalArgumentException. This was reported in https://github.com/usnistgov/oscal-cli/issues/145.

Resolves #156.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- ~~[ ] Have you included examples of how to use your new feature(s)?~~
- ~~[ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.~~
