### PR TITLE
Add "$id" property to generated JSON definitions

### DIFF
--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/json/schema/IDefineableJsonSchema.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/json/schema/IDefineableJsonSchema.java
@@ -100,7 +100,9 @@ public interface IDefineableJsonSchema extends IJsonSchema {
     // create the definition property
     ObjectNode definitionObj = ObjectUtils.notNull(
         definitionsObject.putObject(getDefinitionName(state)));
-    // definitionObj.put("$id", state.getJsonDefinitionRefForDefinition(definition));
+
+    // Add identifier, see usnistgov/metaschema#160
+    definitionObj.put("$id", getDefinitionRef(state));
 
     // generate the definition object contents
     generateSchema(state, definitionObj);


### PR DESCRIPTION
# Committer Notes

Added support for generating a definition `$id` property in JSON schemas. See usnistgov/metaschema#160.

Resolves #151.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
