### PR TITLE
Migrate cli framework

### DIFF
--- a/cli-processor/pom.xml
+++ b/cli-processor/pom.xml
@@ -1,0 +1,96 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>gov.nist.secauto.metaschema</groupId>
+		<artifactId>metaschema-framework</artifactId>
+		<version>0.11.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>cli-processor</artifactId>
+	<packaging>jar</packaging>
+
+	<name>OSCAL CLI Framework</name>
+	<url>http://maven.apache.org</url>
+
+	<properties>
+		<timestamp>${maven.build.timestamp}</timestamp>
+		<maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>gov.nist.secauto.metaschema</groupId>
+			<artifactId>metaschema-model-common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.github.spotbugs</groupId>
+			<artifactId>spotbugs-annotations</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.fusesource.jansi</groupId>
+			<artifactId>jansi</artifactId>
+		</dependency>
+		<!-- <dependency> <groupId>org.jline</groupId>
+		<artifactId>jline-terminal-jansi</artifactId> 
+			</dependency> -->
+		<dependency>
+			<groupId>nl.talsmasoftware</groupId>
+			<artifactId>lazy4j</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.auto.service</groupId>
+			<artifactId>auto-service</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-jul</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>gov.nist.secauto.oscal.tools.oscal-cli</groupId>
+			<artifactId>cli-framework</artifactId>
+			<version>0.3.4-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>io.github.git-commit-id</groupId>
+				<artifactId>git-commit-id-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>templating-maven-plugin</artifactId>
+				<version>1.0.0</version>
+				<executions>
+					<execution>
+						<id>filter-src</id>
+						<goals>
+							<goal>filter-sources</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/cli-processor/spotbugs-exclude.xml
+++ b/cli-processor/spotbugs-exclude.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+	xmlns="https://github.com/spotbugs/filter/3.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+	<Match>
+		<Or>
+			<Bug pattern="EI_EXPOSE_REP" />
+			<Bug pattern="EI_EXPOSE_REP2" />
+		</Or>
+	</Match>
+</FindBugsFilter>

--- a/cli-processor/src/main/java-templates/gov/nist/secauto/metaschema/cli/processor/Version.java
+++ b/cli-processor/src/main/java-templates/gov/nist/secauto/metaschema/cli/processor/Version.java
@@ -1,0 +1,63 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+package gov.nist.secauto.metaschema.cli.processor;
+
+import static org.fusesource.jansi.Ansi.ansi;
+
+import java.io.PrintStream;
+
+public class Version implements VersionInfo {
+
+  public static final String VERSION = "${project.version}";
+  public static final String BUILD_TIMESTAMP = "${timestamp}";
+  public static final String COMMIT = "@git.commit.id.abbrev@";
+
+  public Version() {
+  }
+
+  @Override
+  public String getVersion() {
+    return VERSION;
+  }
+
+  @Override
+  public String getBuildTime() {
+    return BUILD_TIMESTAMP;
+  }
+
+  @Override
+  public String getCommit() {
+    return COMMIT;
+  }
+  
+  @Override
+  public void generateExtraInfo(PrintStream out) {
+    out.println(ansi()
+        .a("Metaschema version ").bold().a(getVersion()).boldOff()
+        .a(" on commit ").bold().a(getCommit()).boldOff()
+        .a(" built at ").bold().a( getBuildTime()).reset());
+  }
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/AbstractExitStatus.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/AbstractExitStatus.java
@@ -1,0 +1,116 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import org.apache.logging.log4j.LogBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public abstract class AbstractExitStatus implements ExitStatus {
+  private static final Logger LOGGER = LogManager.getLogger(AbstractExitStatus.class);
+
+  @NonNull
+  private final ExitCode exitCode;
+
+  private Throwable throwable;
+
+  /**
+   * Construct a new exit status based on the provided {@code exitCode}.
+   * 
+   * @param exitCode
+   *          the exit code
+   */
+  public AbstractExitStatus(@NonNull ExitCode exitCode) {
+    this.exitCode = exitCode;
+  }
+
+  @Override
+  public ExitCode getExitCode() {
+    return exitCode;
+  }
+
+  /**
+   * Get the associated throwable.
+   * 
+   * @return the throwable or {@code null}
+   */
+  @Override
+  public Throwable getThrowable() {
+    return throwable;
+  }
+
+  @Override
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "intended as a exposed property")
+  public ExitStatus withThrowable(@NonNull Throwable throwable) {
+    this.throwable = throwable;
+    return this;
+  }
+
+  /**
+   * Get the associated message.
+   * 
+   * @return the message or {@code null}
+   */
+  @Nullable
+  protected abstract String getMessage();
+
+  @Override
+  public void generateMessage(boolean showStackTrace) {
+    LogBuilder logBuilder = null;
+    if (getExitCode().getStatusCode() <= 0) {
+      if (LOGGER.isInfoEnabled()) {
+        logBuilder = LOGGER.atInfo();
+      }
+    } else if (LOGGER.isErrorEnabled()) {
+      logBuilder = LOGGER.atError();
+    }
+
+    if (logBuilder != null) {
+      Throwable throwable = getThrowable();
+      if (showStackTrace && throwable != null) {
+        logBuilder.withThrowable(throwable);
+      }
+
+      String message = getMessage();
+      if (message == null && throwable != null) {
+        message = throwable.getLocalizedMessage();
+      }
+
+      if (message != null && !message.isEmpty()) {
+        logBuilder.log(message);
+      } else if (throwable != null && showStackTrace) {
+        // log the throwable
+        logBuilder.log();
+      }
+    }
+  }
+
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessor.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessor.java
@@ -1,0 +1,558 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import static org.fusesource.jansi.Ansi.ansi;
+
+import com.google.common.base.Functions;
+
+import gov.nist.secauto.metaschema.cli.processor.command.Command;
+import gov.nist.secauto.metaschema.cli.processor.command.ExtraArgument;
+import gov.nist.secauto.metaschema.model.common.util.IVersionInfo;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.fusesource.jansi.AnsiConsole;
+import org.fusesource.jansi.AnsiPrintStream;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+public class CLIProcessor {
+  private static final Logger LOGGER = LogManager.getLogger(CLIProcessor.class);
+
+  @SuppressWarnings("null")
+  @NonNull
+  public static final Option HELP_OPTION = Option.builder("h")
+      .longOpt("help")
+      .desc("display this help message")
+      .build();
+  @SuppressWarnings("null")
+  @NonNull
+  public static final Option NO_COLOR_OPTION = Option.builder()
+      .longOpt("no-color")
+      .desc("do not colorize output")
+      .build();
+  @SuppressWarnings("null")
+  @NonNull
+  public static final Option QUIET_OPTION = Option.builder("q")
+      .longOpt("quiet")
+      .desc("minimize output to include only errors")
+      .build();
+  @SuppressWarnings("null")
+  @NonNull
+  public static final Option SHOW_STACK_TRACE_OPTION = Option.builder()
+      .longOpt("show-stack-trace")
+      .desc("display the stack trace associated with an error")
+      .build();
+  @SuppressWarnings("null")
+  @NonNull
+  public static final Option VERSION_OPTION = Option.builder()
+      .longOpt("version")
+      .desc("display the application version")
+      .build();
+  @SuppressWarnings("null")
+  @NonNull
+  public static final List<Option> OPTIONS = List.of(
+      HELP_OPTION,
+      NO_COLOR_OPTION,
+      QUIET_OPTION,
+      SHOW_STACK_TRACE_OPTION,
+      VERSION_OPTION);
+
+  @NonNull
+  private final List<Command> commands = new LinkedList<>();
+  @NonNull
+  private final String exec;
+  @NonNull
+  private final List<IVersionInfo> versionInfos;
+
+  public static void main(String... args) {
+    System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
+    CLIProcessor processor = new CLIProcessor("metaschema-cli");
+
+    CommandService.getInstance().getCommands().stream().forEach(command -> {
+      assert command != null;
+      processor.addCommandHandler(command);
+    });
+    System.exit(processor.process(args).getExitCode().getStatusCode());
+  }
+
+  @SuppressWarnings("null")
+  public CLIProcessor(@NonNull String exec) {
+    this(exec, List.of());
+  }
+
+  public CLIProcessor(@NonNull String exec, @NonNull List<IVersionInfo> versionInfos) {
+    this.exec = exec;
+    this.versionInfos = versionInfos;
+    AnsiConsole.systemInstall();
+  }
+
+  /**
+   * Gets the command used to execute for use in help text.
+   * 
+   * @return the command name
+   */
+  @NonNull
+  public String getExec() {
+    return exec;
+  }
+
+  /**
+   * Retrieve the version information for this application.
+   * 
+   * @return the versionInfo
+   */
+  @NonNull
+  public List<IVersionInfo> getVersionInfos() {
+    return versionInfos;
+  }
+
+  public void addCommandHandler(@NonNull Command handler) {
+    commands.add(handler);
+  }
+
+  /**
+   * Process a set of CLIProcessor arguments.
+   * <p>
+   * process().getExitCode().getStatusCode()
+   * 
+   * @param args
+   *          the arguments to process
+   * @return the exit status
+   */
+  public ExitStatus process(String... args) {
+    return parseCommand(args);
+  }
+
+  private ExitStatus parseCommand(String... args) {
+    List<String> commandArgs = Arrays.asList(args);
+    assert commandArgs != null;
+    CallingContext callingContext = new CallingContext(commandArgs);
+
+    ExitStatus status;
+    // the first two arguments should be the <command> and <operation>, where <type> is the object type
+    // the <operation> is performed against.
+    if (commandArgs.isEmpty()) {
+      status = ExitCode.INVALID_COMMAND.exit();
+      callingContext.showHelp();
+    } else {
+      status = callingContext.processCommand();
+    }
+    return status;
+  }
+
+  protected List<Command> getTopLevelCommands() {
+    List<Command> retval = Collections.unmodifiableList(commands);
+    assert retval != null;
+    return retval;
+  }
+
+  private static void handleNoColor() {
+    System.setProperty(AnsiConsole.JANSI_MODE, AnsiConsole.JANSI_MODE_STRIP);
+    AnsiConsole.systemUninstall();
+  }
+
+  public static void handleQuiet() {
+    @SuppressWarnings("resource")
+    LoggerContext ctx = (LoggerContext) LogManager.getContext(false); // NOPMD not
+                                                                      // closable here
+    Configuration config = ctx.getConfiguration();
+    LoggerConfig loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
+    Level oldLevel = loggerConfig.getLevel();
+    if (oldLevel.isLessSpecificThan(Level.ERROR)) {
+      loggerConfig.setLevel(Level.ERROR);
+      ctx.updateLoggers();
+    }
+  }
+
+  protected void showVersion() {
+    @SuppressWarnings("resource")
+    PrintStream out = AnsiConsole.out(); // NOPMD - not owner
+    getVersionInfos().stream().forEach((info) -> {
+      out.println(ansi()
+          .bold().a(getExec()).boldOff()
+          .a(info.getName())
+          .a(" version ")
+          .bold().a(info.getVersion()).boldOff()
+          .a(" built on ")
+          .bold().a(info.getBuildTimestamp()).boldOff()
+          .a(" on commit ")
+          .bold().a(info.getGitCommit())
+          .reset());
+    });
+    out.flush();
+  }
+
+//  @SuppressWarnings("null")
+//  @NonNull
+//  public String[] getArgArray() {
+//    return Stream.concat(options.stream(), extraArgs.stream()).toArray(size -> new String[size]);
+//  }
+  
+  public class CallingContext {
+    @NonNull
+    private final List<Option> options;
+    @NonNull
+    private final Deque<Command> calledCommands;
+    @NonNull
+    private final List<String> extraArgs;
+
+    public CallingContext(@NonNull List<String> args) {
+      Map<String, Command> topLevelCommandMap = getTopLevelCommands().stream()
+          .collect(Collectors.toUnmodifiableMap(Command::getName, Functions.identity()));
+      
+      List<Option> options = new LinkedList<>(OPTIONS);
+      Deque<Command> calledCommands = new LinkedList<>();
+      List<String> extraArgs = new LinkedList<>();
+
+      boolean endArgs = false;
+      for (String arg : args) {
+        if (!endArgs) {
+          if (arg.startsWith("-")) {
+            extraArgs.add(arg);
+          } else if ("--".equals(arg)) {
+            endArgs = true;
+          } else {
+            Command command;
+            if (calledCommands.isEmpty()) {
+              command = topLevelCommandMap.get(arg);
+            } else {
+              command = calledCommands.getLast();
+              command = command.getSubCommandByName(arg);
+            }
+
+            if (command == null) {
+              extraArgs.add(arg);
+            } else {
+              calledCommands.add(command);
+            }
+          }
+        } else {
+          extraArgs.add(arg);
+        }
+      }
+
+      if (LOGGER.isDebugEnabled()) {
+        String commandChain = calledCommands.stream()
+            .map(command -> command.getName())
+            .collect(Collectors.joining(" -> "));
+        LOGGER.debug("Processing command chain: {}", commandChain);
+      }
+
+      for (Command cmd : calledCommands) {
+        options.addAll(cmd.gatherOptions());
+      }
+
+      options = Collections.unmodifiableList(options);
+      extraArgs = Collections.unmodifiableList(extraArgs);
+
+      assert options != null;
+      assert extraArgs != null;
+      
+      this.options = options;
+      this.calledCommands = calledCommands;
+      this.extraArgs = extraArgs;
+    }
+
+    @Nullable
+    protected Command getTargetCommand() {
+      return calledCommands.peekLast();
+    }
+
+    @NonNull
+    protected List<Option> getOptionsList() {
+      return options;
+    }
+
+    @NonNull
+    private Deque<Command> getCalledCommands() {
+      return calledCommands;
+    }
+
+    @NonNull
+    protected List<String> getExtraArgs() {
+      return extraArgs;
+    }
+
+    protected Options toOptions() {
+      Options retval = new Options();
+      for (Option option : getOptionsList()) {
+        retval.addOption(option);
+      }
+      return retval;
+    }
+    
+    public ExitStatus processCommand() {
+      CommandLineParser parser = new DefaultParser();
+      CommandLine cmdLine;
+      try {
+        cmdLine = parser.parse(toOptions(), getExtraArgs().toArray(new String[0]));
+      } catch (ParseException ex) {
+        String msg = ex.getMessage();
+        assert msg != null;
+        return handleInvalidCommand(msg);
+      }
+
+      if (cmdLine.hasOption(NO_COLOR_OPTION)) {
+        handleNoColor();
+      }
+
+      if (cmdLine.hasOption(QUIET_OPTION)) {
+        handleQuiet();
+      }
+
+      ExitStatus retval = null;
+      if (cmdLine.hasOption(VERSION_OPTION)) {
+        showVersion();
+        retval = ExitCode.OK.exit();
+      } else if (cmdLine.hasOption(HELP_OPTION)) {
+        showHelp();
+        retval = ExitCode.OK.exit();
+        // } else {
+        // retval = handleInvalidCommand(commandResult, options,
+        // "Invalid command arguments: " + cmdLine.getArgList().stream().collect(Collectors.joining(" ")));
+      }
+
+      if (retval == null) {
+        retval = invokeCommand(cmdLine);
+      }
+
+      retval.generateMessage(cmdLine.hasOption(SHOW_STACK_TRACE_OPTION));
+      return retval;
+    }
+
+    protected ExitStatus invokeCommand(@NonNull CommandLine cmdLine) {
+      for (Command cmd : getCalledCommands()) {
+        try {
+          cmd.validateOptions(this, cmdLine);
+        } catch (InvalidArgumentException ex) {
+          String msg = ex.getMessage();
+          assert msg != null;
+          return handleInvalidCommand(msg);
+        }
+      }
+
+      Command targetCommand = getTargetCommand();
+      ExitStatus retval;
+      if (targetCommand == null) {
+        retval = ExitCode.INVALID_COMMAND.exit();
+      } else {
+        retval = targetCommand.executeCommand(this, cmdLine);
+      }
+
+      if (ExitCode.INVALID_COMMAND.equals(retval.getExitCode())) {
+        showHelp();
+      }
+      return retval;
+    }
+
+    @NonNull
+    public ExitStatus handleInvalidCommand(
+        @NonNull String message) {
+      showHelp();
+      return ExitCode.INVALID_COMMAND.exitMessage(message);
+    }
+
+    /**
+     * Callback for providing a help header.
+     * 
+     * @return the header or {@code null}
+     */
+    @Nullable
+    protected String buildHelpHeader() {
+      // TODO: build a suitable header
+      return null;
+    }
+
+    /**
+     * Callback for providing a help footer.
+     * 
+     * @param exec
+     *          the executable name
+     * 
+     * @return the footer or {@code null}
+     */
+    @NonNull
+    private String buildHelpFooter() {
+
+      Command targetCommand = getTargetCommand();
+      Collection<Command> subCommands;
+      if (targetCommand == null) {
+        subCommands = getTopLevelCommands();
+      } else {
+        subCommands = targetCommand.getSubCommands();
+      }
+
+      String retval;
+      if (subCommands.isEmpty()) {
+        retval = "";
+      } else {
+        StringBuilder builder = new StringBuilder(64);
+        builder
+            .append(System.lineSeparator())
+            .append("The following are available commands:")
+            .append(System.lineSeparator());
+
+        int length = subCommands.stream()
+            .mapToInt(command -> command.getName().length())
+            .max().orElse(0);
+
+        for (Command command : subCommands) {
+          builder.append(
+              ansi()
+                  .render(String.format("   @|bold %-" + length + "s|@ %s%n",
+                      command.getName(),
+                      command.getDescription())));
+        }
+        builder
+            .append(System.lineSeparator())
+            .append('\'')
+            .append(getExec())
+            .append(" <command> --help' will show help on that specific command.")
+            .append(System.lineSeparator());
+        retval = builder.toString();
+        assert retval != null;
+      }
+      return retval;
+    }
+
+    /**
+     * Get the CLI syntax.
+     * 
+     * @return the CLI syntax to display in help output
+     */
+    protected String buildHelpCliSyntax() {
+
+      StringBuilder builder = new StringBuilder(64);
+      builder.append(getExec());
+
+      Deque<Command> calledCommands = getCalledCommands();
+      if (!calledCommands.isEmpty()) {
+        builder.append(calledCommands.stream()
+            .map(Command::getName)
+            .collect(Collectors.joining(" ", " ", "")));
+      }
+
+      Command targetCommand = getTargetCommand();
+      if (targetCommand == null) {
+        builder.append(" <command>");
+      } else {
+        Collection<Command> subCommands = targetCommand.getSubCommands();
+
+        if (!subCommands.isEmpty()) {
+          builder.append(' ');
+          if (!targetCommand.isSubCommandRequired()) {
+            builder.append('[');
+          }
+
+          builder.append("<command>");
+
+          if (!targetCommand.isSubCommandRequired()) {
+            builder.append(']');
+          }
+        }
+      }
+
+      builder.append(" [<options>]");
+
+      if (targetCommand != null) {
+        // handle extra arguments
+        for (ExtraArgument argument : targetCommand.getExtraArguments()) {
+          builder.append(' ');
+          if (!argument.isRequired()) {
+            builder.append('[');
+          }
+
+          builder.append('<');
+          builder.append(argument.getName());
+          builder.append('>');
+
+          if (argument.getNumber() > 1) {
+            builder.append("...");
+          }
+
+          if (!argument.isRequired()) {
+            builder.append(']');
+          }
+        }
+      }
+
+      String retval = builder.toString();
+      assert retval != null;
+      return retval;
+    }
+
+    public void showHelp() {
+
+      HelpFormatter formatter = new HelpFormatter();
+
+      AnsiPrintStream out = AnsiConsole.out();
+      int terminalWidth = Math.max(out.getTerminalWidth(), 40);
+
+      @SuppressWarnings("resource")
+      PrintWriter writer = new PrintWriter(out, true, StandardCharsets.UTF_8); // NOPMD -
+                                                                               // not owned
+      formatter.printHelp(
+          writer,
+          terminalWidth,
+          buildHelpCliSyntax(),
+          buildHelpHeader(),
+          toOptions(),
+          HelpFormatter.DEFAULT_LEFT_PAD,
+          HelpFormatter.DEFAULT_DESC_PAD,
+          buildHelpFooter(),
+          false);
+      writer.flush();
+    }
+  }
+
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CommandService.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CommandService.java
@@ -1,0 +1,76 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import gov.nist.secauto.metaschema.cli.processor.command.Command;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+import java.util.stream.Collectors;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import nl.talsmasoftware.lazy4j.Lazy;
+
+public final class CommandService {
+  private static final Lazy<CommandService> INSTANCE = Lazy.lazy(() -> new CommandService());
+  @NonNull
+  private final ServiceLoader<Command> loader;
+
+  /**
+   * Get the singleton instance of the function service.
+   *
+   * @return the service instance
+   */
+  public static CommandService getInstance() {
+    return INSTANCE.get();
+  }
+
+  public CommandService() {
+    ServiceLoader<Command> loader = ServiceLoader.load(Command.class);
+    assert loader != null;
+    this.loader = loader;
+  }
+
+  /**
+   * Get the function service loader instance.
+   *
+   * @return the service loader instance.
+   */
+  @NonNull
+  private ServiceLoader<Command> getLoader() {
+    return loader;
+  }
+
+  @SuppressWarnings("null")
+  @NonNull
+  public List<Command> getCommands() {
+    return getLoader().stream()
+        .map(Provider<Command>::get)
+        .collect(Collectors.toUnmodifiableList());
+  }
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/ExitCode.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/ExitCode.java
@@ -1,0 +1,86 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public enum ExitCode {
+  OK(0),
+  FAIL(1),
+  INPUT_ERROR(2),
+  INVALID_COMMAND(3),
+  INVALID_TARGET(4),
+  PROCESSING_ERROR(5);
+
+  private final int statusCode;
+
+  ExitCode(int statusCode) {
+    this.statusCode = statusCode;
+  }
+
+  /**
+   * Get the related status code for use with {@link System#exit(int)}.
+   * 
+   * @return the statusCode
+   */
+  public int getStatusCode() {
+    return statusCode;
+  }
+
+  /**
+   * Exit without a message.
+   * 
+   * @return the exit status
+   */
+  @NonNull
+  public ExitStatus exit() {
+    return new NonMessageExitStatus(this);
+  }
+
+  /**
+   * Exit with the associated message.
+   * 
+   * @return the exit status
+   */
+  @NonNull
+  public ExitStatus exitMessage() {
+    return new MessageExitStatus(this);
+  }
+
+  /**
+   * Exit with the associated message and message arguments.
+   * 
+   * @param messageArguments
+   *          any message parameters
+   * 
+   * @return the exit status
+   */
+  @NonNull
+  public ExitStatus exitMessage(@NonNull Object... messageArguments) {
+    return new MessageExitStatus(this, messageArguments);
+  }
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/ExitStatus.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/ExitStatus.java
@@ -1,0 +1,62 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+public interface ExitStatus {
+  /**
+   * Get the exit code information associated with this exit status.
+   * 
+   * @return the exit code information
+   */
+  @NonNull
+  ExitCode getExitCode();
+
+  @Nullable
+  Throwable getThrowable();
+
+  /**
+   * Process the exit status.
+   * 
+   * @param showStackTrace
+   *          include the stack trace for the throwable, if associated
+   * @see #withThrowable(Throwable)
+   */
+  void generateMessage(boolean showStackTrace);
+
+  /**
+   * Associate a throwable with the exit status.
+   * 
+   * @param throwable
+   *          the throwable
+   * @return this exit status
+   */
+  @NonNull
+  ExitStatus withThrowable(@NonNull Throwable throwable);
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/InvalidArgumentException.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/InvalidArgumentException.java
@@ -1,0 +1,76 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.ParseException;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class InvalidArgumentException
+    extends ParseException {
+
+  /**
+   * the serial version UID.
+   */
+  private static final long serialVersionUID = 1L;
+
+  /** The option that had the invalid argument. */
+  private Option option;
+
+  /**
+   * Generate a new exception.
+   * 
+   * @param message
+   *          the message
+   */
+  public InvalidArgumentException(String message) {
+    super(message);
+  }
+
+  /**
+   * Return the option requiring an argument that wasn't provided on the command line.
+   *
+   * @return the related option
+   */
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intended to expose option for error handling")
+  public Option getOption() {
+    return option;
+  }
+
+  /**
+   * Assign the option requiring an argument that wasn't provided on the command line.
+   * 
+   * @param option
+   *          the option to set
+   */
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "intended to expose option for error handling")
+  public void setOption(@NonNull Option option) {
+    this.option = option;
+  }
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/MessageExitStatus.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/MessageExitStatus.java
@@ -1,0 +1,75 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class MessageExitStatus
+    extends AbstractExitStatus {
+  private final List<Object> messageArguments;
+
+  /**
+   * Construct a new {@link ExitStatus} based on an array of message arguments.
+   * 
+   * @param code
+   *          the exit code to use.
+   * @param messageArguments
+   *          the arguments that can be passed to a formatted string to generate the message
+   */
+  public MessageExitStatus(@NonNull ExitCode code, @NonNull Object... messageArguments) {
+    super(code);
+    if (messageArguments.length == 0) {
+      this.messageArguments = Collections.emptyList();
+    } else {
+      this.messageArguments = Arrays.asList(messageArguments);
+    }
+  }
+
+  @Override
+  public String getMessage() {
+    String format = lookupMessageForCode(getExitCode());
+    return String.format(format, messageArguments.toArray());
+  }
+
+  private String lookupMessageForCode(@SuppressWarnings("unused") ExitCode ignoredExitCode) {
+    // TODO: add message bundle support
+    StringBuilder builder = new StringBuilder();
+    // builder.append(getExitCode()).append(":");
+    for (int index = 1; index <= messageArguments.size(); index++) {
+      if (index > 1) {
+        builder.append(' ');
+      }
+      builder.append("%s");
+      // builder.append(index);
+    }
+    return builder.toString();
+  }
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/NonMessageExitStatus.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/NonMessageExitStatus.java
@@ -1,0 +1,46 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class NonMessageExitStatus
+    extends AbstractExitStatus {
+
+  /**
+   * Construct a new message status.
+   */
+  NonMessageExitStatus(@NonNull ExitCode code) {
+    super(code);
+  }
+
+  @Override
+  protected String getMessage() {
+    // always null
+    return null;
+  }
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/OptionUtils.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/OptionUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import org.apache.commons.cli.Option;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public final class OptionUtils {
+
+  private OptionUtils() {
+    // disable construction
+  }
+
+  @NonNull
+  public static String toArgument(@NonNull Option option) {
+    return option.hasLongOpt() ? "--" + option.getLongOpt() : "-" + option.getOpt();
+  }
+
+
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/VersionInfo.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/VersionInfo.java
@@ -1,0 +1,44 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import java.io.PrintStream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public interface VersionInfo {
+  @NonNull
+  String getVersion();
+
+  @NonNull
+  String getBuildTime();
+
+  @NonNull
+  String getCommit();
+
+  void generateExtraInfo(@NonNull PrintStream out);
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractParentCommand.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractParentCommand.java
@@ -1,0 +1,91 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor.command;
+
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.ExitCode;
+import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
+
+import org.apache.commons.cli.CommandLine;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public abstract class AbstractParentCommand implements Command {
+  @NonNull
+  private final Map<String, Command> commandToSubcommandHandlerMap;
+  private final boolean subCommandRequired;
+
+  @SuppressWarnings("null")
+  protected AbstractParentCommand(boolean subCommandRequired) {
+    this.commandToSubcommandHandlerMap = Collections.synchronizedMap(new LinkedHashMap<>());
+    this.subCommandRequired = subCommandRequired;
+  }
+
+  protected void addCommandHandler(Command handler) {
+    String commandName = handler.getName();
+    this.commandToSubcommandHandlerMap.put(commandName, handler);
+  }
+
+  @Override
+  public Command getSubCommandByName(String name) {
+    return commandToSubcommandHandlerMap.get(name);
+  }
+
+  @SuppressWarnings("null")
+  @Override
+  public Collection<Command> getSubCommands() {
+    return Collections.unmodifiableCollection(commandToSubcommandHandlerMap.values());
+  }
+
+  @Override
+  public boolean isSubCommandRequired() {
+    return subCommandRequired;
+  }
+
+  @Override
+  public ExitStatus executeCommand(CallingContext callingContext, CommandLine cmdLine) {
+    callingContext.showHelp();
+    ExitStatus status;
+    if (isSubCommandRequired()) {
+      status = ExitCode.INVALID_COMMAND
+          .exitMessage("Please use one of the following sub-commands: "+
+              getSubCommands().stream()
+          .map(command -> command.getName())
+          .collect(Collectors.joining(", ")));
+    } else {
+      status = ExitCode.OK.exit();
+    }
+    return status; 
+  }
+
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractTerminalCommand.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractTerminalCommand.java
@@ -1,0 +1,52 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor.command;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public abstract class AbstractTerminalCommand implements Command {
+
+  @SuppressWarnings("null")
+  @Override
+  public Collection<Command> getSubCommands() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public boolean isSubCommandRequired() {
+    return false;
+  }
+
+  protected static Path resolvePathAgainstCWD(@NonNull Path path) {
+    return Paths.get("").toAbsolutePath().resolve(path).normalize();
+  }
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/Command.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/Command.java
@@ -1,0 +1,85 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor.command;
+
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
+import gov.nist.secauto.metaschema.cli.processor.InvalidArgumentException;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public interface Command {
+  @NonNull
+  String getName();
+
+  @NonNull
+  String getDescription();
+
+  @SuppressWarnings("null")
+  @NonNull
+  default List<ExtraArgument> getExtraArguments() {
+    return Collections.emptyList();
+  }
+
+  default int requiredExtraArgumentsCount() {
+    return (int) getExtraArguments().stream()
+        .filter(arg -> arg.isRequired())
+        .count();
+  }
+
+  @NonNull
+  default Collection<? extends Option> gatherOptions() {
+    // by default there are no options to handle
+    return Collections.emptyList();
+  }
+
+  default void validateOptions(
+      @NonNull CallingContext callingContext,
+      @NonNull CommandLine cmdLine)
+      throws InvalidArgumentException {
+    // by default there are no options to handle
+  }
+
+  @NonNull
+  ExitStatus executeCommand(@NonNull CallingContext callingContext, @NonNull CommandLine cmdLine);
+
+  @NonNull
+  Collection<Command> getSubCommands();
+
+  boolean isSubCommandRequired();
+
+  default Command getSubCommandByName(String name) {
+    return null;
+  }
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/DefaultExtraArgument.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/DefaultExtraArgument.java
@@ -1,0 +1,62 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor.command;
+
+public class DefaultExtraArgument implements ExtraArgument {
+  private final String name;
+  private final boolean required;
+  private final int number;
+
+  public DefaultExtraArgument(String name, boolean required) {
+    this(name, required, 1);
+  }
+
+  public DefaultExtraArgument(String name, boolean required, int number) {
+    if (number < 1) {
+      throw new IllegalArgumentException("number must be a positive value");
+    }
+    this.name = name;
+    this.required = required;
+    this.number = number;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public boolean isRequired() {
+    return required;
+  }
+
+  @Override
+  public int getNumber() {
+    return number;
+  }
+
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ExtraArgument.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ExtraArgument.java
@@ -1,0 +1,40 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor.command;
+
+public interface ExtraArgument {
+  String getName();
+
+  boolean isRequired();
+
+  /**
+   * The allowed number of arguments of this type.
+   * 
+   * @return a positive integer value
+   */
+  int getNumber();
+}

--- a/cli-processor/src/main/resources/log4j2.xml
+++ b/cli-processor/src/main/resources/log4j2.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configuration>
+<Configuration verbose="true">
+	<Appenders>
+		<Console name="console-trace" target="SYSTEM_ERR" immediateFlush="true">
+			<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n" charset="UTF-8" />
+			<ThresholdFilter level="INFO" onMatch="DENY" onMismatch="ACCEPT" />
+		</Console>
+		<Console name="console-info" target="SYSTEM_ERR" immediateFlush="true">
+			<PatternLayout pattern="%m%n" charset="UTF-8" />
+			<Filters>
+				<ThresholdFilter level="ERROR" onMatch="DENY" onMismatch="ACCEPT" />
+				<ThresholdFilter level="DEBUG" onMatch="DENY" onMismatch="NEUTRAL" />
+				<ThresholdFilter level="TRACE" onMatch="DENY" onMismatch="NEUTRAL" />
+			</Filters>
+		</Console>
+		<Console name="console-error" target="SYSTEM_ERR" immediateFlush="true">
+<!--			<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n" charset="UTF-8" />-->
+			<PatternLayout pattern="%m%n" charset="UTF-8" />
+			<ThresholdFilter level="ERROR" onMatch="ACCEPT" onMismatch="DENY" />
+		</Console>
+	</Appenders>
+	<Loggers>
+		<Root level="INFO">
+			<AppenderRef ref="console-trace" />
+			<AppenderRef ref="console-info" />
+			<AppenderRef ref="console-error" />
+		</Root>
+	</Loggers>
+</Configuration>

--- a/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/ExitCodeTest.java
+++ b/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/ExitCodeTest.java
@@ -1,0 +1,110 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Logging solution based on
+ * https://stackoverflow.com/questions/24205093/how-to-create-a-custom-appender-in-log4j2
+ */
+class ExitCodeTest {
+  private static MockedAppender mockedAppender;
+  private static Logger logger;
+
+  @BeforeEach
+  public void setup() {
+    mockedAppender.events.clear();
+  }
+
+  @BeforeAll
+  public static void setupClass() {
+    mockedAppender = new MockedAppender();
+    logger = (Logger) LogManager.getLogger(AbstractExitStatus.class);
+    logger.addAppender(mockedAppender);
+    // logger.setLevel(Level.INFO);
+    mockedAppender.start();
+  }
+
+  @Test
+  void testExitMessage() {
+    Throwable ex = new IllegalStateException("a message");
+    ExitStatus exitStatus = ExitCode.FAIL.exit().withThrowable(ex);
+    exitStatus.generateMessage(false);
+
+    List<LogEvent> events = mockedAppender.getEvents();
+    assertAll(
+        () -> assertEquals(1, events.size()),
+        () -> assertEquals("a message", events.get(0).getMessage().getFormattedMessage()));
+  }
+
+  @Test
+  void testExitThrown() {
+    Throwable ex = new IllegalStateException("a message");
+    ExitStatus exitStatus = ExitCode.FAIL.exit().withThrowable(ex);
+    exitStatus.generateMessage(true);
+
+    List<LogEvent> events = mockedAppender.getEvents();
+    assertAll(
+        () -> assertEquals(1, events.size()),
+        () -> assertEquals(ex, events.get(0).getThrown()),
+        () -> assertEquals("a message", events.get(0).getMessage().getFormattedMessage()));
+  }
+
+  private static class MockedAppender
+      extends AbstractAppender {
+
+    private final List<LogEvent> events = new LinkedList<>();
+
+    protected MockedAppender() {
+      super("MockedAppender", null, null, false, null);
+    }
+
+    public List<LogEvent> getEvents() {
+      return events;
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      synchronized (this) {
+        events.add(event.toImmutable());
+      }
+    }
+  }
+}

--- a/metaschema-cli/pom.xml
+++ b/metaschema-cli/pom.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>gov.nist.secauto.metaschema</groupId>
+		<artifactId>metaschema-framework</artifactId>
+		<version>0.11.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>metaschema-cli</artifactId>
+
+	<name>Metaschema Command Line Tool</name>
+
+	<url>${site.url}${project.artifactId}/</url>
+	<distributionManagement>
+		<site>
+			<id>nist-pages</id>
+			<url>${site.url}${project.artifactId}/</url>
+		</site>
+	</distributionManagement>
+
+	<description>A simple command line tool supporting common Metaschema
+		operations.</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>cli-processor</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>metaschema-schema-generator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>metaschema-java-binding</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.auto.service</groupId>
+			<artifactId>auto-service</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.spotbugs</groupId>
+			<artifactId>spotbugs-annotations</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+			</resource>
+			<resource>
+				<directory>src/main/distro</directory>
+				<filtering>true</filtering>
+				<targetPath>${project.build.directory}/generated-distro</targetPath>
+			</resource>
+			<resource>
+				<directory>
+					${project.build.directory}/generated-resources/license</directory>
+			</resource>
+		</resources>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>appassembler-maven-plugin</artifactId>
+				<configuration>
+					<programs>
+						<program>
+							<mainClass>gov.nist.secauto.metaschema.cli.CLI</mainClass>
+							<id>metaschema-cli</id>
+						</program>
+					</programs>
+					<generateRepository>false</generateRepository>
+					<repositoryLayout>flat</repositoryLayout>
+					<repositoryName>lib</repositoryName>
+					<outputFileNameMapping>
+						@{groupId}@.@{artifactId}@-@{version}@.@{extension}@</outputFileNameMapping>
+					<extraJvmArguments>-Dsun.stdout.encoding=UTF-8
+						-Dsun.stderr.encoding=UTF-8</extraJvmArguments>
+					<projectArtifactFirstInClassPath>true</projectArtifactFirstInClassPath>
+					<includeConfigurationDirectoryInClasspath>false</includeConfigurationDirectoryInClasspath>
+				</configuration>
+				<executions>
+					<execution>
+						<id>exec-cli-windows</id>
+						<phase>package</phase>
+						<goals>
+							<goal>assemble</goal>
+						</goals>
+						<configuration>
+							<useWildcardClassPath>true</useWildcardClassPath>
+							<platforms>windows</platforms>
+						</configuration>
+					</execution>
+					<execution>
+						<id>exec-cli-bash</id>
+						<phase>package</phase>
+						<goals>
+							<goal>assemble</goal>
+						</goals>
+						<configuration>
+							<platforms>unix</platforms>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifest>
+							<mainClass>gov.nist.secauto.metaschema.cli.CLI</mainClass>
+							<addClasspath>true</addClasspath>
+							<!-- <classpathPrefix>lib/</classpathPrefix> -->
+							<classpathLayoutType>custom</classpathLayoutType>
+							<customClasspathLayout>${artifact.groupId}.${artifact.artifactId}-$${artifact.version}.${artifact.extension}</customClasspathLayout>
+						</manifest>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<dependencies>
+					<dependency>
+						<groupId>gov.nist.secauto.swid</groupId>
+						<artifactId>swid-maven-plugin</artifactId>
+						<version>0.7.0</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>make-assembly-bin</id> <!-- this is used for inheritance merges -->
+						<phase>package</phase> <!-- bind to the packaging phase -->
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<descriptors>
+								<descriptor>src/main/assembly/bin.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>license-maven-plugin</artifactId>
+				<version>2.0.0</version>
+				<executions>
+					<execution>
+						<id>third-party-license</id>
+						<goals>
+							<goal>add-third-party</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/generated-distro</outputDirectory>
+							<thirdPartyFilename>LICENSE-THIRD-PARTY.txt</thirdPartyFilename>
+							<licenseMerges>
+								<licenseMerge>The Apache Software License, Version 2.0|Apache
+									License, Version 2.0|Apache Public License 2.0</licenseMerge>
+							</licenseMerges>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/metaschema-cli/schema-test.json
+++ b/metaschema-cli/schema-test.json
@@ -1,0 +1,181 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "$id" : "http://csrc.nist.gov/ns/metaschema/testing/fields/with/flags/complex-field-1.0-schema.json",
+  "$comment" : "Metaschema with complex field",
+  "type" : "object",
+  "definitions" : {
+    "FieldComplexFieldComplexField2Type" : {
+      "$id" : "#/definitions/FieldComplexFieldComplexField2Type",
+      "title" : "Complex Field 1",
+      "description" : "A complex field with a flag",
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "$ref" : "#/definitions/FlagComplexFieldIdType"
+        },
+        "STRVALUE" : {
+          "$ref" : "#/definitions/StringDatatype"
+        }
+      },
+      "required" : [ "STRVALUE" ],
+      "additionalProperties" : false
+    },
+    "FlagComplexFieldIdType" : {
+      "$id" : "#/definitions/FlagComplexFieldIdType",
+      "title" : "Identifier",
+      "description" : "The document identifier",
+      "$ref" : "#/definitions/StringDatatype"
+    },
+    "FlagComplexFieldComplexField5NameType" : {
+      "$id" : "#/definitions/FlagComplexFieldComplexField5NameType",
+      "title" : "A flag",
+      "description" : "A simple flag",
+      "$ref" : "#/definitions/StringDatatype"
+    },
+    "AssemblyComplexFieldTopLevelType" : {
+      "$id" : "#/definitions/AssemblyComplexFieldTopLevelType",
+      "title" : "Root",
+      "description" : "Root assembly",
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "$ref" : "#/definitions/FlagComplexFieldIdType"
+        },
+        "complex-field1" : {
+          "$ref" : "#/definitions/FieldComplexFieldComplexField1Type"
+        },
+        "complex-fields2" : {
+          "oneOf" : [ {
+            "$ref" : "#/definitions/FieldComplexFieldComplexField2Type"
+          }, {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/FieldComplexFieldComplexField2Type"
+            },
+            "minItems" : 2
+          } ]
+        },
+        "complex-fields3" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldComplexFieldComplexField3Type"
+          },
+          "minItems" : 2
+        },
+        "complex-fields4" : {
+          "type" : "object",
+          "minProperties" : 1,
+          "propertyNames" : {
+            "$ref" : "#/definitions/StringDatatype"
+          },
+          "additionalProperties" : {
+            "$ref" : "#/definitions/FieldComplexFieldComplexField4Type"
+          }
+        },
+        "complex-fields5" : {
+          "oneOf" : [ {
+            "$ref" : "#/definitions/FieldComplexFieldComplexField5Type"
+          }, {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/FieldComplexFieldComplexField5Type"
+            },
+            "minItems" : 2
+          } ]
+        }
+      },
+      "required" : [ "complex-fields2", "complex-fields3" ],
+      "additionalProperties" : false
+    },
+    "FieldComplexFieldComplexField1Type" : {
+      "$id" : "#/definitions/FieldComplexFieldComplexField1Type",
+      "title" : "Complex Field 1",
+      "description" : "A complex field with a flag",
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "$ref" : "#/definitions/FlagComplexFieldIdType"
+        },
+        "STRVALUE" : {
+          "$ref" : "#/definitions/StringDatatype"
+        }
+      },
+      "required" : [ "STRVALUE" ],
+      "additionalProperties" : false
+    },
+    "FieldComplexFieldComplexField3Type" : {
+      "$id" : "#/definitions/FieldComplexFieldComplexField3Type",
+      "title" : "Complex Field 3",
+      "description" : "A complex field with a flag",
+      "type" : "object",
+      "properties" : {
+        "id2" : {
+          "$ref" : "#/definitions/FlagComplexFieldComplexField3Id2Type"
+        },
+        "STRVALUE" : {
+          "$ref" : "#/definitions/StringDatatype"
+        }
+      },
+      "required" : [ "STRVALUE" ],
+      "additionalProperties" : false
+    },
+    "FlagComplexFieldComplexField3Id2Type" : {
+      "$id" : "#/definitions/FlagComplexFieldComplexField3Id2Type",
+      "title" : "A flag",
+      "description" : "A simple flag",
+      "$ref" : "#/definitions/StringDatatype"
+    },
+    "FieldComplexFieldComplexField4Type" : {
+      "$id" : "#/definitions/FieldComplexFieldComplexField4Type",
+      "title" : "Complex Field 4",
+      "description" : "A complex field with a flag",
+      "$ref" : "#/definitions/StringDatatype"
+    },
+    "FlagComplexFieldComplexField4Id2Type" : {
+      "$id" : "#/definitions/FlagComplexFieldComplexField4Id2Type",
+      "title" : "A flag",
+      "description" : "A simple flag",
+      "$ref" : "#/definitions/StringDatatype"
+    },
+    "FieldComplexFieldComplexField5Type" : {
+      "$id" : "#/definitions/FieldComplexFieldComplexField5Type",
+      "title" : "Complex Field 5",
+      "description" : "A complex field with a flag that is collapsible",
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "$ref" : "#/definitions/FlagComplexFieldComplexField5NameType"
+        },
+        "STRVALUE" : {
+          "oneOf" : [ {
+            "$ref" : "#/definitions/StringDatatype"
+          }, {
+            "type" : "array",
+            "minItems" : 1,
+            "items" : {
+              "$ref" : "#/definitions/StringDatatype"
+            }
+          } ]
+        }
+      },
+      "required" : [ "STRVALUE" ],
+      "additionalProperties" : false
+    },
+    "StringDatatype" : {
+      "description" : "A non-empty string with leading and trailing whitespace disallowed. Whitespace is: U+9, U+10, U+32 or [ \n\t]+",
+      "type" : "string",
+      "pattern" : "^\\S(.*\\S)?$"
+    }
+  },
+  "properties" : {
+    "$schema" : {
+      "type" : "string",
+      "format" : "uri-reference"
+    },
+    "top-level" : {
+      "$ref" : "#/definitions/AssemblyComplexFieldTopLevelType"
+    }
+  },
+  "required" : [ "top-level" ],
+  "additionalProperties" : false
+}

--- a/metaschema-cli/spotbugs-exclude.xml
+++ b/metaschema-cli/spotbugs-exclude.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+	xmlns="https://github.com/spotbugs/filter/3.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+	<Match>
+		<Or>
+			<Bug pattern="EI_EXPOSE_REP" />
+			<Bug pattern="EI_EXPOSE_REP2" />
+		</Or>
+	</Match>
+</FindBugsFilter>

--- a/metaschema-cli/src/main/assembly/bin.xml
+++ b/metaschema-cli/src/main/assembly/bin.xml
@@ -1,0 +1,64 @@
+<assembly
+	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	<id>metaschema-cli</id>
+	<formats>
+		<format>dir</format>
+		<format>zip</format>
+		<format>tar.bz2</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<dependencySets>
+		<dependencySet>
+			<outputDirectory>/lib</outputDirectory>
+			<outputFileNameMapping>${artifact.groupId}.${artifact.artifactId}-${artifact.version}.${artifact.extension}</outputFileNameMapping>
+			<useProjectArtifact>true</useProjectArtifact>
+		</dependencySet>
+	</dependencySets>
+	<fileSets>
+		<fileSet>
+			<directory>${project.basedir}</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>README*</include>
+				<include>LICENSE*</include>
+				<include>NOTICE*</include>
+			</includes>
+		</fileSet>
+		<fileSet>
+			<directory>${project.build.directory}/generated-distro</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>**/*</include>
+			</includes>
+		</fileSet>
+		<fileSet>
+			<directory>${project.build.directory}/appassembler</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>**/*</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+	<containerDescriptorHandlers>
+		<containerDescriptorHandler>
+			<handlerName>swid-generator</handlerName>
+			<configuration>
+<!-- 				<excludes> -->
+<!-- 					<exclude>${artifact}</exclude> -->
+<!-- 				</excludes> -->
+				<entities>
+					<entity>
+						<name>National Institute of Standards and Technology</name>
+						<regid>nist.gov</regid>
+						<roles>
+							<role>tagCreator</role>
+							<role>softwareCreator</role>
+						</roles>
+					</entity>
+				</entities>
+			</configuration>
+		</containerDescriptorHandler>
+	</containerDescriptorHandlers>
+</assembly>

--- a/metaschema-cli/src/main/distro/LICENSE.txt
+++ b/metaschema-cli/src/main/distro/LICENSE.txt
@@ -1,0 +1,27 @@
+## This project is in the worldwide public domain
+
+As a work of the United States government, this project is in the public domain within the United States under the National Institute of Standards and Technology Software License.
+
+Additionally, this work is made available in the public domain worldwide using the CC0 1.0 Universal public domain dedication (https://creativecommons.org/publicdomain/zero/1.0/).
+
+### National-Institute of Standards and Technology Software License
+
+Portions of this software was developed by employees of the National Institute of Standards and Technology (NIST), an agency of the Federal Government and is being made available as a public service. Pursuant to title 17 United States Code Section 105, works of NIST employees are not subject to copyright protection in the United States.  This software may be subject to foreign copyright.  Permission in the United States and in foreign countries, to the extent that NIST may hold copyright, to use, copy, modify, create derivative works, and distribute this software and its documentation without fee is hereby granted on a non-exclusive basis, provided that this notice and disclaimer of warranty appears in all copies. 
+
+THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM, OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY, CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+
+### CC0 1.0 Universal Summary
+
+This is a human-readable summary of the Legal Code (read the full text at https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+#### No Copyright
+
+The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.
+
+You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.
+
+#### Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law. When using or citing the work, you should not imply endorsement by the author or the affirmer.

--- a/metaschema-cli/src/main/distro/README.txt
+++ b/metaschema-cli/src/main/distro/README.txt
@@ -1,0 +1,32 @@
+Metaschema Command line Tool v${project.version}
+
+Overview:
+---------
+
+This open-source, tool offers a convenient way to manipulate Metaschema based
+content supporting the following operations:
+
+- Validating a Metaschema model definition to ensure it is well-formed and valid.
+- Generating XML and JSON Schemas from a Metaschema model definition.
+
+More information can be found at: https://github.com/usnistgov/metaschema-java
+
+Requirements:
+-------------
+
+Requires installation of a Java runtime environment version 11 or newer
+
+Use:
+----
+
+The tool has an integrated help feature that explains the various command line options and commands.
+
+The tool can be run as follows:
+
+metaschema-cli --help
+
+Feedback:
+---------
+
+Please post issues about tool defects, enhancement requests, and any other related
+comments in the tool's GitHub repository at https://github.com/usnistgov/metaschema-java.

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/CLI.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/CLI.java
@@ -1,0 +1,65 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli;
+
+import gov.nist.secauto.metaschema.cli.commands.GenerateSchemaCommand;
+import gov.nist.secauto.metaschema.cli.commands.ValidateCommand;
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor;
+import gov.nist.secauto.metaschema.cli.processor.CommandService;
+import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
+import gov.nist.secauto.metaschema.model.MetaschemaVersion;
+import gov.nist.secauto.metaschema.model.common.util.IVersionInfo;
+import gov.nist.secauto.metaschema.model.common.util.MetaschemaJavaVersion;
+
+import java.util.List;
+
+/**
+ * Hello world!
+ *
+ */
+public class CLI {
+  public static void main(String[] args) {
+    System.exit(runCli(args).getExitCode().getStatusCode());
+  }
+
+  public static ExitStatus runCli(String[] args) {
+    System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
+
+    List<IVersionInfo> versions = List.of(
+        new MetaschemaJavaVersion(),
+        new MetaschemaVersion());
+    CLIProcessor processor = new CLIProcessor("metaschema-cli",versions);
+    processor.addCommandHandler(new ValidateCommand());
+    processor.addCommandHandler(new GenerateSchemaCommand());
+
+    CommandService.getInstance().getCommands().stream().forEach(command -> {
+      assert command != null;
+      processor.addCommandHandler(command);
+    });
+    return processor.process(args);
+  }
+}

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
@@ -1,0 +1,200 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.commands;
+
+import gov.nist.secauto.metaschema.binding.IBindingContext;
+import gov.nist.secauto.metaschema.binding.io.Format;
+import gov.nist.secauto.metaschema.binding.io.IBoundLoader;
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.ExitCode;
+import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
+import gov.nist.secauto.metaschema.cli.processor.InvalidArgumentException;
+import gov.nist.secauto.metaschema.cli.processor.OptionUtils;
+import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;
+import gov.nist.secauto.metaschema.cli.processor.command.DefaultExtraArgument;
+import gov.nist.secauto.metaschema.cli.processor.command.ExtraArgument;
+import gov.nist.secauto.metaschema.model.common.util.CustomCollectors;
+import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public abstract class AbstractConvertSubcommand
+    extends AbstractTerminalCommand {
+  private static final Logger LOGGER = LogManager.getLogger(AbstractConvertSubcommand.class);
+
+  @NonNull
+  private static final String COMMAND = "convert";
+  @NonNull
+  private static final List<ExtraArgument> EXTRA_ARGUMENTS = ObjectUtils.notNull(List.of(
+      new DefaultExtraArgument("source file", true),
+      new DefaultExtraArgument("destination file", false)));
+
+  @NonNull
+  private static final Option OVERWRITE_OPTION = ObjectUtils.notNull(
+      Option.builder()
+          .longOpt("overwrite")
+          .desc("overwrite the destination if it exists")
+          .build());
+  @NonNull
+  private static final Option TO_OPTION = ObjectUtils.notNull(
+      Option.builder()
+          .longOpt("to")
+          .required()
+          .hasArg().argName("FORMAT")
+          .desc("convert to format: xml, json, or yaml")
+          .build());
+
+  @Override
+  public String getName() {
+    return COMMAND;
+  }
+
+  @Override
+  public Collection<? extends Option> gatherOptions() {
+    return ObjectUtils.notNull(List.of(
+        OVERWRITE_OPTION,
+        TO_OPTION));
+  }
+
+  @Override
+  public List<ExtraArgument> getExtraArguments() {
+    return EXTRA_ARGUMENTS;
+  }
+
+  @Override
+  public void validateOptions(CallingContext callingContext, CommandLine cmdLine) throws InvalidArgumentException {
+
+    try {
+      String toFormatText = cmdLine.getOptionValue(TO_OPTION);
+      Format.valueOf(toFormatText.toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException ex) {
+      InvalidArgumentException newEx = new InvalidArgumentException(
+          String.format("Invalid '%s' argument. The format must be one of: %s.",
+              OptionUtils.toArgument(TO_OPTION),
+              Format.names().stream()
+                  .collect(CustomCollectors.joiningWithOxfordComma("and"))));
+      newEx.setOption(TO_OPTION);
+      newEx.addSuppressed(ex);
+      throw newEx;
+    }
+
+    List<String> extraArgs = cmdLine.getArgList();
+    if (extraArgs.isEmpty() || extraArgs.size() > 2) {
+      throw new InvalidArgumentException("Illegal number of arguments.");
+    }
+
+    Path source = Paths.get(extraArgs.get(0));
+    if (!Files.exists(source)) {
+      throw new InvalidArgumentException("The provided source '" + source + "' does not exist.");
+    }
+    if (!Files.isReadable(source)) {
+      throw new InvalidArgumentException("The provided source '" + source + "' is not readable.");
+    }
+  }
+
+  @NonNull
+  protected abstract IBindingContext getBindingContext();
+
+  @SuppressWarnings({
+      "PMD.OnlyOneReturn", // readability
+      "PMD.CyclomaticComplexity", "PMD.CognitiveComplexity" // reasonable
+  })
+  @Override
+  public ExitStatus executeCommand(CallingContext callingContext, CommandLine cmdLine) {
+
+    List<String> extraArgs = cmdLine.getArgList();
+
+    Path destination = null;
+    if (extraArgs.size() > 1) {
+      destination = Paths.get(extraArgs.get(1)).toAbsolutePath();
+    }
+
+    if (destination != null) {
+      if (Files.exists(destination)) {
+        if (!cmdLine.hasOption(OVERWRITE_OPTION)) {
+          return ExitCode.FAIL.exitMessage(
+              String.format("The provided destination '%s' already exists and the '%s' option was not provided.",
+                  destination,
+                  OptionUtils.toArgument(OVERWRITE_OPTION)));
+        }
+        if (!Files.isWritable(destination)) {
+          return ExitCode.FAIL.exitMessage(
+              "The provided destination '" + destination + "' is not writable.");
+        }
+      } else {
+        Path parent = destination.getParent();
+        if (parent != null) {
+          try {
+            Files.createDirectories(parent);
+          } catch (IOException ex) {
+            return ExitCode.INVALID_TARGET.exit().withThrowable(ex); // NOPMD readability
+          }
+        }
+      }
+    }
+
+    Path source = Paths.get(extraArgs.get(0));
+
+    String toFormatText = cmdLine.getOptionValue(TO_OPTION);
+    Format toFormat = Format.valueOf(toFormatText.toUpperCase(Locale.ROOT));
+
+    IBindingContext bindingContext = getBindingContext();
+    try {
+      IBoundLoader loader = bindingContext.newBoundLoader();
+      if (destination == null) {
+        loader.convert(source, System.out, toFormat, getLoadedClass());
+      } else {
+        loader.convert(source, destination, toFormat, getLoadedClass());
+      }
+    } catch (IOException | IllegalArgumentException ex) {
+      return ExitCode.FAIL.exit().withThrowable(ex); // NOPMD readability
+    }
+    if (destination != null && LOGGER.isInfoEnabled()) {
+      LOGGER.info("Generated {} file: {}", toFormat.toString(), destination);
+    }
+    return ExitCode.OK.exit();
+  }
+
+  protected abstract Class<?> getLoadedClass();
+
+  public String getLoadedClassSimpleName() {
+    return getLoadedClass().getSimpleName();
+  }
+}

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
@@ -1,0 +1,245 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.commands;
+
+import gov.nist.secauto.metaschema.binding.IBindingContext;
+import gov.nist.secauto.metaschema.binding.IBindingContext.IValidationSchemaProvider;
+import gov.nist.secauto.metaschema.binding.io.Format;
+import gov.nist.secauto.metaschema.binding.io.IBoundLoader;
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor;
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.ExitCode;
+import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
+import gov.nist.secauto.metaschema.cli.processor.InvalidArgumentException;
+import gov.nist.secauto.metaschema.cli.processor.OptionUtils;
+import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;
+import gov.nist.secauto.metaschema.cli.processor.command.DefaultExtraArgument;
+import gov.nist.secauto.metaschema.cli.processor.command.ExtraArgument;
+import gov.nist.secauto.metaschema.cli.util.LoggingValidationHandler;
+import gov.nist.secauto.metaschema.model.ConstraintLoader;
+import gov.nist.secauto.metaschema.model.common.MetaschemaException;
+import gov.nist.secauto.metaschema.model.common.constraint.IConstraintSet;
+import gov.nist.secauto.metaschema.model.common.util.CustomCollectors;
+import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
+import gov.nist.secauto.metaschema.model.common.validation.IValidationResult;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.xml.sax.SAXException;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+public abstract class AbstractValidateContentCommand
+    extends AbstractTerminalCommand
+    implements IValidationSchemaProvider {
+  private static final Logger LOGGER = LogManager.getLogger(AbstractValidateContentCommand.class);
+  @NonNull
+  private static final String COMMAND = "validate";
+  @NonNull
+  private static final List<ExtraArgument> EXTRA_ARGUMENTS = ObjectUtils.notNull(List.of(
+      new DefaultExtraArgument("file to validate", true)));
+
+  @NonNull
+  private static final Option AS_OPTION = ObjectUtils.notNull(
+      Option.builder()
+          .longOpt("as")
+          .hasArg()
+          .argName("FORMAT")
+          .desc("source format: xml, json, or yaml")
+          .build());
+  @NonNull
+  private static final Option CONSTRAINTS_OPTION = ObjectUtils.notNull(
+      Option.builder("c")
+          .hasArg()
+          .argName("FILE")
+          .desc("additional constraint definitions")
+          .build());
+
+  @Override
+  public String getName() {
+    return COMMAND;
+  }
+
+  @SuppressWarnings("null")
+  @Override
+  public Collection<? extends Option> gatherOptions() {
+    return List.of(
+        AS_OPTION,
+        CONSTRAINTS_OPTION);
+  }
+
+  @Override
+  public List<ExtraArgument> getExtraArguments() {
+    return EXTRA_ARGUMENTS;
+  }
+
+  @Override
+  public void validateOptions(CallingContext callingContext, CommandLine cmdLine) throws InvalidArgumentException {
+    if (cmdLine.hasOption(CONSTRAINTS_OPTION)) {
+      String[] args = cmdLine.getOptionValues(CONSTRAINTS_OPTION);
+      for (String arg : args) {
+        Path constraint = Paths.get(arg);
+        if (!Files.exists(constraint)) {
+          throw new InvalidArgumentException(
+              "The provided external constraint file '" + constraint + "' does not exist.");
+        }
+        if (!Files.isRegularFile(constraint)) {
+          throw new InvalidArgumentException(
+              "The provided external constraint file '" + constraint + "' is not a file.");
+        }
+        if (!Files.isReadable(constraint)) {
+          throw new InvalidArgumentException(
+              "The provided external constraint file '" + constraint + "' is not readable.");
+        }
+      }
+    }
+
+    List<String> extraArgs = cmdLine.getArgList();
+    if (extraArgs.size() != 1) {
+      throw new InvalidArgumentException("The source to validate must be provided.");
+    }
+
+    Path source = Paths.get(extraArgs.get(0));
+    if (!Files.exists(source)) {
+      throw new InvalidArgumentException("The provided source file '" + source + "' does not exist.");
+    }
+    if (!Files.isReadable(source)) {
+      throw new InvalidArgumentException("The provided source file '" + source + "' is not readable.");
+    }
+
+    if (cmdLine.hasOption(AS_OPTION)) {
+      try {
+        String toFormatText = cmdLine.getOptionValue(AS_OPTION);
+        Format.valueOf(toFormatText.toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException ex) {
+        throw new InvalidArgumentException(
+            String.format("Invalid '%s' argument. The format must be one of: %s.",
+                OptionUtils.toArgument(AS_OPTION),
+                Arrays.asList(Format.values()).stream()
+                    .map(format -> format.name())
+                    .collect(CustomCollectors.joiningWithOxfordComma("and"))));
+      }
+    }
+  }
+
+  @NonNull
+  protected abstract IBindingContext getBindingContext(@Nullable Set<IConstraintSet> constraintSets);
+
+  @Override
+  public ExitStatus executeCommand(CallingContext callingContext, CommandLine cmdLine) {
+    IBindingContext bindingContext;
+    if (cmdLine.hasOption(CONSTRAINTS_OPTION)) {
+      ConstraintLoader constraintLoader = new ConstraintLoader();
+      Set<IConstraintSet> constraintSets = new LinkedHashSet<>();
+      String[] args = cmdLine.getOptionValues(CONSTRAINTS_OPTION);
+      for (String arg : args) {
+        Path constraintPath = Paths.get(arg);
+        assert constraintPath != null;
+        try {
+          constraintSets.add(constraintLoader.load(constraintPath));
+        } catch (IOException | MetaschemaException ex) {
+          return ExitCode.FAIL.exitMessage("Unable to load constraint set '" + arg + "'.").withThrowable(ex);
+        }
+      }
+      bindingContext = getBindingContext(constraintSets);
+    } else {
+      bindingContext = getBindingContext(null);
+    }
+
+    IBoundLoader loader = bindingContext.newBoundLoader();
+
+    List<String> extraArgs = cmdLine.getArgList();
+    @SuppressWarnings("null")
+    Path source = resolvePathAgainstCWD(Paths.get(extraArgs.get(0)));
+    assert source != null;
+
+    Format asFormat;
+    if (cmdLine.hasOption(AS_OPTION)) {
+      try {
+        String toFormatText = cmdLine.getOptionValue(AS_OPTION);
+        asFormat = Format.valueOf(toFormatText.toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException ex) {
+        return ExitCode.FAIL
+            .exitMessage("Invalid '--as' argument. The format must be one of: "
+                + Arrays.stream(Format.values())
+                    .map(format -> format.name())
+                    .collect(CustomCollectors.joiningWithOxfordComma("or")))
+            .withThrowable(ex);
+      }
+    } else {
+      // attempt to determine the format
+      try {
+        asFormat = loader.detectFormat(source);
+      } catch (FileNotFoundException ex) {
+        // this case was already checked for
+        return ExitCode.INPUT_ERROR.exitMessage("The provided source file '" + source + "' does not exist.");
+      } catch (IOException ex) {
+        return ExitCode.FAIL.exit().withThrowable(ex);
+      } catch (IllegalArgumentException ex) {
+        return ExitCode.FAIL.exitMessage(
+            "Source file has unrecognizable format. Use '--as' to specify the format. The format must be one of: "
+                + Arrays.stream(Format.values())
+                    .map(format -> format.name())
+                    .collect(CustomCollectors.joiningWithOxfordComma("or")));
+      }
+    }
+
+    IValidationResult validationResult;
+    try {
+      validationResult = bindingContext.validate(source, asFormat, this);
+    } catch (IOException | SAXException ex) {
+      return ExitCode.PROCESSING_ERROR.exit().withThrowable(ex);
+    }
+
+    if (LOGGER.isInfoEnabled()) {
+      LOGGER.info("Validation identified the following in file '{}'.", source);
+    }
+
+    LoggingValidationHandler.handleValidationResults(validationResult);
+
+    if (!cmdLine.hasOption(CLIProcessor.QUIET_OPTION) && LOGGER.isInfoEnabled()) {
+      LOGGER.info("The file '{}' is valid.", source);
+    }
+
+    return (validationResult.isPassing() ? ExitCode.OK : ExitCode.FAIL).exit();
+  }
+}

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
@@ -1,0 +1,219 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.commands;
+
+import gov.nist.secauto.metaschema.binding.io.Format;
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.ExitCode;
+import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
+import gov.nist.secauto.metaschema.cli.processor.InvalidArgumentException;
+import gov.nist.secauto.metaschema.cli.processor.OptionUtils;
+import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;
+import gov.nist.secauto.metaschema.cli.processor.command.DefaultExtraArgument;
+import gov.nist.secauto.metaschema.cli.processor.command.ExtraArgument;
+import gov.nist.secauto.metaschema.model.MetaschemaLoader;
+import gov.nist.secauto.metaschema.model.common.IMetaschema;
+import gov.nist.secauto.metaschema.model.common.MetaschemaException;
+import gov.nist.secauto.metaschema.model.common.configuration.DefaultConfiguration;
+import gov.nist.secauto.metaschema.model.common.configuration.IMutableConfiguration;
+import gov.nist.secauto.metaschema.model.common.util.CustomCollectors;
+import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
+import gov.nist.secauto.metaschema.schemagen.ISchemaGenerator;
+import gov.nist.secauto.metaschema.schemagen.ISchemaGenerator.SchemaFormat;
+import gov.nist.secauto.metaschema.schemagen.SchemaGenerationFeature;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class GenerateSchemaCommand
+    extends AbstractTerminalCommand {
+  private static final Logger LOGGER = LogManager.getLogger(GenerateSchemaCommand.class);
+
+  @NonNull
+  private static final String COMMAND = "generate-schema";
+  @NonNull
+  private static final List<ExtraArgument> EXTRA_ARGUMENTS;
+  @NonNull
+  private static final Option OVERWRITE_OPTION = ObjectUtils.notNull(
+      Option.builder()
+          .longOpt("overwrite")
+          .desc("overwrite the destination if it exists")
+          .build());
+  @NonNull
+  private static final Option AS_OPTION = ObjectUtils.notNull(
+      Option.builder()
+          .longOpt("as")
+          .hasArg()
+          .argName("FORMAT")
+          .desc("source format: xml, json, or yaml")
+          .build());
+  @NonNull
+  private static final Option INLINE_TYPES_OPTION = ObjectUtils.notNull(
+      Option.builder()
+          .longOpt("inline-types")
+          .desc("definitions declared inline will be generated as inline types")
+          .build());
+  static {
+    EXTRA_ARGUMENTS = ObjectUtils.notNull(List.of(
+        new DefaultExtraArgument("metaschema file", true),
+        new DefaultExtraArgument("destination schema file", false)));
+  }
+
+  @Override
+  public String getName() {
+    return COMMAND;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Generate a schema for the specified Metaschema";
+  }
+
+  @SuppressWarnings("null")
+  @Override
+  public Collection<? extends Option> gatherOptions() {
+    return List.of(
+        OVERWRITE_OPTION,
+        AS_OPTION,
+        INLINE_TYPES_OPTION);
+  }
+
+  @Override
+  public List<ExtraArgument> getExtraArguments() {
+    return EXTRA_ARGUMENTS;
+  }
+
+  @Override
+  public void validateOptions(CallingContext callingContext, CommandLine cmdLine) throws InvalidArgumentException {
+    try {
+      String toFormatText = cmdLine.getOptionValue(AS_OPTION);
+      SchemaFormat.valueOf(toFormatText.toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException ex) {
+      InvalidArgumentException newEx = new InvalidArgumentException( // NOPMD - intentional
+          String.format("Invalid '%s' argument. The format must be one of: %s.",
+              OptionUtils.toArgument(AS_OPTION),
+              Arrays.asList(Format.values()).stream()
+                  .map(format -> format.name())
+                  .collect(CustomCollectors.joiningWithOxfordComma("and"))));
+      newEx.setOption(AS_OPTION);
+      newEx.addSuppressed(ex);
+      throw newEx;
+    }
+
+    List<String> extraArgs = cmdLine.getArgList();
+    if (extraArgs.isEmpty() || extraArgs.size() > 2) {
+      throw new InvalidArgumentException("Illegal number of arguments.");
+    }
+
+    Path metaschema = Paths.get(extraArgs.get(0));
+    if (!Files.exists(metaschema)) {
+      throw new InvalidArgumentException("The provided metaschema '" + metaschema + "' does not exist.");
+    }
+    if (!Files.isReadable(metaschema)) {
+      throw new InvalidArgumentException("The provided metaschema '" + metaschema + "' is not readable.");
+    }
+  }
+
+  @Override
+  public ExitStatus executeCommand(CallingContext callingContext, CommandLine cmdLine) {
+    List<String> extraArgs = cmdLine.getArgList();
+
+    Path destination = null;
+    if (extraArgs.size() > 1) {
+      destination = Paths.get(extraArgs.get(1)).toAbsolutePath();
+    }
+
+    if (destination != null) {
+      if (Files.exists(destination)) {
+        if (!cmdLine.hasOption(OVERWRITE_OPTION)) {
+          return ExitCode.FAIL.exitMessage( // NOPMD readability
+              String.format("The provided destination '%s' already exists and the '%s' option was not provided.",
+                  destination,
+                  OptionUtils.toArgument(OVERWRITE_OPTION)));
+        }
+        if (!Files.isWritable(destination)) {
+          return ExitCode.FAIL.exitMessage( // NOPMD readability
+              "The provided destination '" + destination + "' is not writable.");
+        }
+      } else {
+        Path parent = destination.getParent();
+        if (parent != null) {
+          try {
+            Files.createDirectories(parent);
+          } catch (IOException ex) {
+            return ExitCode.INVALID_TARGET.exit().withThrowable(ex); // NOPMD readability
+          }
+        }
+      }
+    }
+
+    String asFormatText = cmdLine.getOptionValue(AS_OPTION);
+    SchemaFormat asFormat = SchemaFormat.valueOf(asFormatText.toUpperCase(Locale.ROOT));
+
+    IMutableConfiguration<SchemaGenerationFeature> configuration
+        = new DefaultConfiguration<>(SchemaGenerationFeature.class);
+    if (cmdLine.hasOption(INLINE_TYPES_OPTION)) {
+      configuration.enableFeature(SchemaGenerationFeature.INLINE_DEFINITIONS);
+      if (SchemaFormat.JSON.equals(asFormat)) {
+        configuration.disableFeature(SchemaGenerationFeature.INLINE_CHOICE_DEFINITIONS);
+      } else {
+        configuration.enableFeature(SchemaGenerationFeature.INLINE_CHOICE_DEFINITIONS);
+      }
+    }
+
+    Path input = Paths.get(extraArgs.get(0));
+    assert input != null;
+    try {
+      IMetaschema metaschema = new MetaschemaLoader().load(input);
+      if (destination == null) {
+        ISchemaGenerator.generateSchema(metaschema, ObjectUtils.notNull(System.out), asFormat, configuration);
+      } else {
+        ISchemaGenerator.generateSchema(metaschema, destination, asFormat, configuration);
+      }
+    } catch (IOException | MetaschemaException ex) {
+      return ExitCode.FAIL.exit().withThrowable(ex); // NOPMD readability
+    }
+    if (destination != null && LOGGER.isInfoEnabled()) {
+      LOGGER.info("Generated {} schema file: {}", asFormat.toString(), destination);
+    }
+    return ExitCode.OK.exit();
+  }
+
+}

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateCommand.java
@@ -1,0 +1,138 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.commands;
+
+import gov.nist.secauto.metaschema.binding.io.xml.XmlUtil;
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor;
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.ExitCode;
+import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
+import gov.nist.secauto.metaschema.cli.processor.InvalidArgumentException;
+import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;
+import gov.nist.secauto.metaschema.cli.processor.command.DefaultExtraArgument;
+import gov.nist.secauto.metaschema.cli.processor.command.ExtraArgument;
+import gov.nist.secauto.metaschema.cli.util.LoggingValidationHandler;
+import gov.nist.secauto.metaschema.model.MetaschemaLoader;
+import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
+import gov.nist.secauto.metaschema.model.common.validation.IContentValidator;
+import gov.nist.secauto.metaschema.model.common.validation.IValidationResult;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.xml.sax.SAXException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.xml.transform.Source;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class ValidateCommand
+    extends AbstractTerminalCommand {
+  private static final Logger LOGGER = LogManager.getLogger(ValidateCommand.class);
+  @NonNull
+  private static final String COMMAND = "validate";
+  @NonNull
+  private static final List<ExtraArgument> EXTRA_ARGUMENTS;
+
+  static {
+    EXTRA_ARGUMENTS = ObjectUtils.notNull(List.of(
+        new DefaultExtraArgument("Metaschema file to validate", true)));
+  }
+
+  @Override
+  public String getName() {
+    return COMMAND;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Validate that the specified Metaschema is well-formed and valid to the Metaschema model";
+  }
+
+  @Override
+  public List<ExtraArgument> getExtraArguments() {
+    return EXTRA_ARGUMENTS;
+  }
+
+  protected List<Source> getXmlSchemaSources() throws IOException {
+    List<Source> retval = new LinkedList<>();
+    retval.add(XmlUtil.getStreamSource(
+        MetaschemaLoader.class.getResource("/schema/xml/metaschema.xsd")));
+    return Collections.unmodifiableList(retval);
+  }
+
+  @Override
+  public void validateOptions(CallingContext callingContext, CommandLine cmdLine) throws InvalidArgumentException {
+    List<String> extraArgs = cmdLine.getArgList();
+    if (extraArgs.size() != 1) {
+      throw new InvalidArgumentException("The source to validate must be provided.");
+    }
+
+    File target = new File(extraArgs.get(0));
+    if (!target.exists()) {
+      throw new InvalidArgumentException("The provided source file '" + target.getPath() + "' does not exist.");
+    }
+    if (!target.canRead()) {
+      throw new InvalidArgumentException("The provided source file '" + target.getPath() + "' is not readable.");
+    }
+  }
+
+  @Override
+  public ExitStatus executeCommand(CallingContext callingContext, CommandLine cmdLine) {
+    List<String> extraArgs = cmdLine.getArgList();
+    Path target = Paths.get(extraArgs.get(0));
+
+    IValidationResult schemaValidationResult;
+    try {
+      List<Source> schemaSources = getXmlSchemaSources();
+      schemaValidationResult = IContentValidator.validateWithXmlSchema(target, schemaSources);
+    } catch (IOException | SAXException ex) {
+      return ExitCode.PROCESSING_ERROR.exit().withThrowable(ex);
+    }
+
+    if (!schemaValidationResult.isPassing()) {
+      if (LOGGER.isErrorEnabled()) {
+        LOGGER.error("The file '{}' has schema validation issue(s). The issues are:", target);
+      }
+      LoggingValidationHandler.handleValidationResults(schemaValidationResult);
+      return ExitCode.FAIL.exit();
+    }
+
+    if (!cmdLine.hasOption(CLIProcessor.QUIET_OPTION) && LOGGER.isInfoEnabled()) {
+      LOGGER.info("The file '{}' is valid.", target);
+    }
+    return ExitCode.OK.exit();
+  }
+}

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/package-info.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.commands;

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/util/LoggingValidationHandler.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/util/LoggingValidationHandler.java
@@ -1,0 +1,159 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.util;
+
+import static org.fusesource.jansi.Ansi.ansi;
+
+import gov.nist.secauto.metaschema.model.common.constraint.ConstraintValidationFinding;
+import gov.nist.secauto.metaschema.model.common.constraint.IConstraint.Level;
+import gov.nist.secauto.metaschema.model.common.validation.IValidationFinding;
+import gov.nist.secauto.metaschema.model.common.validation.IValidationResult;
+import gov.nist.secauto.metaschema.model.common.validation.JsonSchemaContentValidator.JsonValidationFinding;
+import gov.nist.secauto.metaschema.model.common.validation.XmlSchemaContentValidator.XmlValidationFinding;
+
+import org.apache.logging.log4j.LogBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.fusesource.jansi.Ansi;
+import org.fusesource.jansi.Ansi.Color;
+import org.xml.sax.SAXParseException;
+
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public final class LoggingValidationHandler {
+  private static final Logger LOGGER = LogManager.getLogger(LoggingValidationHandler.class);
+
+  private LoggingValidationHandler() {
+    // disable construction
+  }
+
+  public static boolean handleValidationResults(IValidationResult result) {
+    handleValidationFindings(result.getFindings());
+    return result.isPassing();
+  }
+
+  public static void handleValidationFindings(@NonNull List<? extends IValidationFinding> findings) {
+    for (IValidationFinding finding : findings) {
+      if (finding instanceof JsonValidationFinding) {
+        handleJsonValidationFinding((JsonValidationFinding) finding);
+      } else if (finding instanceof XmlValidationFinding) {
+        handleXmlValidationFinding((XmlValidationFinding) finding);
+      } else if (finding instanceof ConstraintValidationFinding) {
+        handleConstraintValidationFinding((ConstraintValidationFinding) finding);
+      } else {
+        throw new IllegalStateException();
+      }
+    }
+  }
+  
+  public static void handleJsonValidationFinding(@NonNull JsonValidationFinding finding) {
+    Ansi ansi = generatePreamble(finding.getSeverity());
+
+    getLogger(finding).log(
+        ansi.a('[')
+            .fgBright(Color.WHITE)
+            .a(finding.getCause().getPointerToViolation())
+            .reset()
+            .a(']')
+            .format(" %s [%s]",
+                finding.getMessage(),
+                finding.getDocumentUri().toString()));
+  }
+
+  public static void handleXmlValidationFinding(XmlValidationFinding finding) {
+    Ansi ansi = generatePreamble(finding.getSeverity());
+    SAXParseException ex = finding.getCause();
+
+    getLogger(finding).log(
+        ansi.format("%s [%s{%d,%d}]",
+            finding.getMessage(),
+            finding.getDocumentUri().toString(),
+            ex.getLineNumber(),
+            ex.getColumnNumber()));
+  }
+
+  public static void handleConstraintValidationFinding(@NonNull ConstraintValidationFinding finding) {
+    Ansi ansi = generatePreamble(finding.getSeverity());
+
+    getLogger(finding).log(
+        ansi.format("[%s] %s", finding.getNode().getMetapath(), finding.getMessage()));
+  }
+
+  @NonNull
+  private static LogBuilder getLogger(@NonNull IValidationFinding finding) {
+    LogBuilder retval;
+    switch (finding.getSeverity()) {
+    case CRITICAL:
+      retval = LOGGER.atFatal();
+      break;
+    case ERROR:
+      retval = LOGGER.atError();
+      break;
+    case WARNING:
+      retval = LOGGER.atWarn();
+      break;
+    case INFORMATIONAL:
+      retval = LOGGER.atInfo();
+      break;
+    default:
+      throw new IllegalArgumentException("Unknown level: " + finding.getSeverity().name());
+    }
+
+    if (finding.getCause() != null) {
+      retval.withThrowable(finding.getCause());
+    }
+
+    return retval;
+  }
+
+  @NonNull
+  private static Ansi generatePreamble(@NonNull Level level) {
+    Ansi ansi = ansi().fgBright(Color.WHITE).a('[').reset();
+
+    switch (level) {
+    case CRITICAL:
+      ansi = ansi.fgRed().a("CRITICAL").reset();
+      break;
+    case ERROR:
+      ansi = ansi.fgBrightRed().a("ERROR").reset();
+      break;
+    case WARNING:
+      ansi = ansi.fgBrightYellow().a("WARNING").reset();
+      break;
+    case INFORMATIONAL:
+      ansi = ansi.fgBrightBlue().a("INFO").reset();
+      break;
+    default:
+      ansi = ansi().fgBright(Color.MAGENTA).a(level.name()).reset();
+      break;
+    }
+    ansi = ansi.fgBright(Color.WHITE).a("] ").reset();
+    return ansi;
+  }
+}

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/util/package-info.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/util/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.util;

--- a/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
+++ b/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
@@ -1,0 +1,89 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import gov.nist.secauto.metaschema.cli.processor.ExitCode;
+import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.MultipleFailuresError;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Unit test for simple CLI.
+ */
+public class CLITest {
+  @Test
+  void testHelp() {
+    String[] args = {};
+    evaluateResult(CLI.runCli(args), ExitCode.INVALID_COMMAND);
+  }
+
+  @Test
+  void testHelpArg() {
+    String[] args = { "-h" };
+    evaluateResult(CLI.runCli(args), ExitCode.OK);
+  }
+
+  @Test
+  void testMetaschemaValidate() {
+    String[] args = { "validate",
+        "../metaschema-java-codegen/src/test/resources/metaschema/fields_with_flags/metaschema.xml" };
+    evaluateResult(CLI.runCli(args), ExitCode.OK);
+  }
+
+  @Test
+  void testMetaschemaGenerateSchema() {
+    String[] args = { "generate-schema", "--overwrite", "--as", "JSON",
+        "../metaschema-java-codegen/src/test/resources/metaschema/fields_with_flags/metaschema.xml",
+        "schema-test.json" };
+    evaluateResult(CLI.runCli(args), ExitCode.OK);
+  }
+
+  void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode) {
+    status.generateMessage(true);
+    assertAll(
+        () -> assertEquals(expectedCode, status.getExitCode(), "exit code mismatch"),
+        () -> assertNull(status.getThrowable(), "expected null Throwable"));
+  }
+
+  void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode,
+      @NonNull Class<? extends Throwable> thrownClass) {
+    status.generateMessage(true);
+    Throwable thrown = status.getThrowable();
+    assert thrown != null;
+    assertAll(
+        () -> assertEquals(expectedCode, status.getExitCode(), "exit code mismatch"),
+        () -> assertEquals(thrownClass, thrown.getClass(), "expected Throwable mismatch"));
+  }
+}

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/DefaultBindingContext.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/DefaultBindingContext.java
@@ -254,14 +254,4 @@ public class DefaultBindingContext implements IBindingContext {
     return DefaultNodeItemFactory.instance().newNodeItem(classBinding, boundObject, baseUri, rootNode);
   }
 
-  @Override
-  public IValidationResult validate(@NonNull INodeItem nodeItem) {
-    DynamicContext context = new StaticContext().newDynamicContext();
-    context.setDocumentLoader(newBoundLoader());
-    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
-    DefaultConstraintValidator validator = new DefaultConstraintValidator(context, handler);
-    validator.validate(nodeItem);
-    return handler;
-  }
-
 }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/DefaultBoundLoader.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/DefaultBoundLoader.java
@@ -135,11 +135,7 @@ public class DefaultBoundLoader implements IBoundLoader {
     return configuration;
   }
 
-  /**
-   * Get the configured Metaschema binding context to use to load Java types.
-   *
-   * @return the binding context
-   */
+  @Override
   public IBindingContext getBindingContext() {
     return bindingContext;
   }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/Format.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/Format.java
@@ -26,6 +26,14 @@
 
 package gov.nist.secauto.metaschema.binding.io;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Selections of serialization formats.
  */
@@ -33,13 +41,38 @@ public enum Format {
   /**
    * The <a href="https://www.w3.org/XML/">Extensible Markup Language</a> format.
    */
-  XML,
+  XML(".xml"),
   /**
    * The <a href="https://www.json.org/">JavaScript Object Notation</a> format.
    */
-  JSON,
+  JSON(".json"),
   /**
    * The <a href="https://yaml.org/">YAML Ain't Markup Language</a> format.
    */
-  YAML;
+  YAML(".yml");
+
+  private static final List<String> NAMES;
+
+  @NonNull
+  private final String defaultExtension;
+
+  static {
+    NAMES = Arrays.stream(values())
+        .map(format -> format.name().toLowerCase(Locale.ROOT))
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  @SuppressFBWarnings(value = "MS_EXPOSE_REP", justification = "Exposes names provided by the enum")
+  public static List<String> names() {
+    return NAMES;
+  }
+
+  Format(@NonNull String defaultExtension) {
+    this.defaultExtension = defaultExtension;
+  }
+
+  @NonNull
+  public String getDefaultExtension() {
+    return defaultExtension;
+  }
 }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/DefaultJsonDeserializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/DefaultJsonDeserializer.java
@@ -79,6 +79,7 @@ public class DefaultJsonDeserializer<CLASS>
   @NonNull
   protected JsonParser newJsonParser(@NonNull Reader reader) throws IOException {
     JsonParser retval = getJsonFactory().createParser(reader);
+    // avoid automatically closing streams not owned by the parser
     retval.configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, false);
     return retval;
 

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/DefaultJsonSerializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/DefaultJsonSerializer.java
@@ -28,6 +28,7 @@ package gov.nist.secauto.metaschema.binding.io.json;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonGenerator.Feature;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 
 import gov.nist.secauto.metaschema.binding.IBindingContext;
@@ -59,6 +60,7 @@ public class DefaultJsonSerializer<CLASS>
       if (jsonFactory == null) {
         jsonFactory = getJsonFactoryInstance();
       }
+      assert jsonFactory != null;
       return jsonFactory;
     }
   }
@@ -72,6 +74,7 @@ public class DefaultJsonSerializer<CLASS>
   protected JsonGenerator newJsonGenerator(Writer writer) throws IOException {
     JsonFactory factory = getJsonFactory();
     JsonGenerator retval = factory.createGenerator(writer);
+    // avoid automatically closing streams not owned by the generator
     retval.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
     retval.setPrettyPrinter(new DefaultPrettyPrinter());
     return retval;

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/JsonFactoryFactory.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/JsonFactoryFactory.java
@@ -27,6 +27,7 @@
 package gov.nist.secauto.metaschema.binding.io.json;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser.Feature;
 
 public final class JsonFactoryFactory {
   private static final JsonFactory SINGLETON = newJsonFactoryInstance();
@@ -36,7 +37,10 @@ public final class JsonFactoryFactory {
   }
 
   public static JsonFactory newJsonFactoryInstance() {
-    return new JsonFactory();
+    JsonFactory retval = new JsonFactory();
+    // avoid automatically closing streams not owned by the reader
+    retval.disable(Feature.AUTO_CLOSE_SOURCE);
+    return retval;
   }
 
   public static JsonFactory instance() {

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/xml/DefaultXmlDeserializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/xml/DefaultXmlDeserializer.java
@@ -93,6 +93,7 @@ public class DefaultXmlDeserializer<CLASS>
 
   @Override
   protected IDocumentNodeItem deserializeToNodeItemInternal(Reader reader, URI documentUri) throws IOException {
+    // doesn't auto close the underlying reader
     try (AutoCloser<XMLEventReader2, XMLStreamException> closer
         = new AutoCloser<>(newXMLEventReader2(reader), event -> event.close())) {
       return parseXmlInternal(closer.getResource(), documentUri);

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/xml/XmlUtil.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/xml/XmlUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+package gov.nist.secauto.metaschema.binding.io.xml;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+public final class XmlUtil {
+
+  private XmlUtil() {
+    // disable construction
+  }
+
+  public static Source getStreamSource(URL url) throws IOException {
+    return new StreamSource(url.openStream(), url.toString());
+  }
+}

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/YamlOperations.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/YamlOperations.java
@@ -1,0 +1,92 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.binding.io.yaml;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+import org.yaml.snakeyaml.resolver.Resolver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public final class YamlOperations {
+  private static final Yaml YAML_PARSER;
+
+  static {
+    Constructor constructor = new Constructor();
+    Representer representer = new Representer();
+    YAML_PARSER = new Yaml(constructor, representer, new DumperOptions(), new Resolver() {
+      @Override
+      protected void addImplicitResolvers() {
+        addImplicitResolver(Tag.BOOL, BOOL, "yYnNtTfFoO");
+        addImplicitResolver(Tag.INT, INT, "-+0123456789");
+        addImplicitResolver(Tag.FLOAT, FLOAT, "-+0123456789.");
+        addImplicitResolver(Tag.MERGE, MERGE, "<");
+        addImplicitResolver(Tag.NULL, NULL, "~nN\0");
+        addImplicitResolver(Tag.NULL, EMPTY, null);
+        // addImplicitResolver(Tag.TIMESTAMP, TIMESTAMP, "0123456789");
+      }
+
+    });
+  }
+
+  private YamlOperations() {
+    // disable construction
+  }
+
+  @SuppressWarnings({ "unchecked", "null" })
+  @NonNull
+  public static Map<String, Object> parseYaml(Path target) throws IOException {
+    try (BufferedReader reader = Files.newBufferedReader(target.toAbsolutePath(), StandardCharsets.UTF_8)) {
+      return (Map<String, Object>) YAML_PARSER.load(reader);
+    }
+  }
+
+  /**
+   * Converts the provided YAML {@code map} into JSON.
+   * 
+   * @param map
+   *          the YAML map
+   * @return the JSON object
+   * @throws JSONException
+   *           if an error occurred while building the JSON tree
+   */
+  public static JSONObject yamlToJson(@NonNull Map<String, Object> map) {
+    return new JSONObject(map);
+  }
+}

--- a/metaschema-model-common/pom.xml
+++ b/metaschema-model-common/pom.xml
@@ -245,6 +245,35 @@
 					</usedDependencies>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>io.github.git-commit-id</groupId>
+				<artifactId>git-commit-id-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>metaschema-java-git-info</id>
+						<goals>
+							<goal>revision</goal>
+						</goals>
+						<phase>initialize</phase>
+						<configuration>
+							<prefix>git</prefix>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>templating-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>filter-src</id>
+						<goals>
+							<goal>filter-sources</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
 			<!-- <plugin> <groupId>com.khubla.antlr</groupId>
 			<artifactId>antlr4test-maven-plugin</artifactId> <configuration>
 			<verbose>false</verbose> 

--- a/metaschema-model-common/src/main/java-templates/gov/nist/secauto/metaschema/model/common/util/MetaschemaJavaVersion.java
+++ b/metaschema-model-common/src/main/java-templates/gov/nist/secauto/metaschema/model/common/util/MetaschemaJavaVersion.java
@@ -1,0 +1,66 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+package gov.nist.secauto.metaschema.model.common.util;
+
+public class MetaschemaJavaVersion implements IVersionInfo {
+
+  public static final String NAME = "metaschema-java";
+  public static final String VERSION = "${project.version}";
+  public static final String BUILD_TIMESTAMP = "${timestamp}";
+  public static final String COMMIT = "@git.commit.id.abbrev@";
+  public static final String BRANCH = "@git.branch@";
+  public static final String CLOSEST_TAG = "@git.closest.tag.name@";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public String getVersion() {
+    return VERSION;
+  }
+
+  @Override
+  public String getBuildTimestamp() {
+    return BUILD_TIMESTAMP;
+  }
+
+  @Override
+  public String getGitCommit() {
+    return COMMIT;
+  }
+
+  @Override
+  public String getGitBranch() {
+    return BRANCH;
+  }
+
+  @Override
+  public String getGitClosestTag() {
+    return CLOSEST_TAG;
+  }
+}

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/util/IVersionInfo.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/util/IVersionInfo.java
@@ -1,0 +1,49 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.model.common.util;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public interface IVersionInfo {
+  @NonNull
+  String getName();
+
+  @NonNull
+  String getVersion();
+
+  @NonNull
+  String getBuildTimestamp();
+
+  @NonNull
+  String getGitCommit();
+
+  @NonNull
+  String getGitBranch();
+
+  @NonNull
+  String getGitClosestTag();
+}

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/validation/AggregateValidationResult.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/validation/AggregateValidationResult.java
@@ -1,0 +1,87 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+package gov.nist.secauto.metaschema.model.common.validation;
+
+import gov.nist.secauto.metaschema.model.common.constraint.IConstraint.Level;
+import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public final class AggregateValidationResult implements IValidationResult {
+  @NonNull
+  private final List<IValidationFinding> findings;
+  @NonNull
+  private final Level highestSeverity;
+
+  private AggregateValidationResult(@NonNull List<IValidationFinding> findings, @NonNull Level highestSeverity) {
+    this.findings = CollectionUtil.unmodifiableList(findings);
+    this.highestSeverity = highestSeverity;
+  }
+
+  public static IValidationResult aggregate(@NonNull IValidationResult result) {
+    return result;
+  }
+
+  public static IValidationResult aggregate(@NonNull IValidationResult... results) {
+    Stream<? extends IValidationFinding> stream = Stream.empty();
+    for (IValidationResult result : results) {
+      stream = Stream.concat(stream, result.getFindings().stream());
+    }
+    assert stream != null;
+    return aggregate(stream);
+  }
+  
+  public static IValidationResult aggregate(@NonNull Stream<? extends IValidationFinding> findingStream) {
+    AtomicReference<Level> highestSeverity = new AtomicReference<>(Level.INFORMATIONAL);
+    
+    List<IValidationFinding> findings = new LinkedList<>();
+    findingStream.sequential().forEachOrdered(finding -> {
+      findings.add(finding);
+      Level severity = finding.getSeverity();
+      if (highestSeverity.get().ordinal() < severity.ordinal()) {
+        highestSeverity.set(severity);
+      }
+    });
+
+    return new AggregateValidationResult(findings, highestSeverity.get());
+  }
+
+  @Override
+  public Level getHighestSeverity() {
+    return highestSeverity;
+  }
+
+  @Override
+  public List<? extends IValidationFinding> getFindings() {
+    return findings;
+  }
+
+}

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/validation/IContentValidator.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/validation/IContentValidator.java
@@ -29,12 +29,19 @@ package gov.nist.secauto.metaschema.model.common.validation;
 import gov.nist.secauto.metaschema.model.common.IResourceLoader;
 import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 
+import org.json.JSONObject;
+import org.json.JSONTokener;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.List;
+
+import javax.xml.transform.Source;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -85,4 +92,41 @@ public interface IContentValidator extends IResourceLoader {
    */
   @NonNull
   IValidationResult validate(@NonNull InputSource source) throws IOException;
+
+  /**
+   * Validate the target using the provided XML schemas.
+   * 
+   * @param target
+   *          the target to validate
+   * @param schemaSources
+   *          the XML schema sources to validate with
+   * @return the validation result
+   * @throws IOException
+   *           if an error occurred while performing validation
+   * @throws SAXException
+   *           if an error occurred while parsing the XML target or schema
+   */
+  @NonNull
+  static IValidationResult validateWithXmlSchema(@NonNull Path target, @NonNull List<Source> schemaSources)
+      throws IOException, SAXException {
+    return new XmlSchemaContentValidator(schemaSources).validate(target);
+  }
+
+  /**
+   * Validate the target using the provided JSON schema.
+   * 
+   * @param target
+   *          the target to validate
+   * @param schema
+   *          the JSON schema to validate with
+   * @return the validation result
+   * @throws IOException
+   *           if an error occurred while performing validation
+   * @see {@link JsonSchemaContentValidator#toJsonObject(InputStream)}
+   */
+  @NonNull
+  static IValidationResult validateWithJsonSchema(@NonNull Path target, @NonNull JSONObject schema)
+      throws IOException {
+    return new JsonSchemaContentValidator(schema).validate(target);
+  }
 }

--- a/metaschema-model/pom.xml
+++ b/metaschema-model/pom.xml
@@ -240,6 +240,35 @@
 					</usedDependencies>
 				</configuration>
 			</plugin>
+						<plugin>
+				<groupId>io.github.git-commit-id</groupId>
+				<artifactId>git-commit-id-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>metaschema-git-info</id>
+						<goals>
+							<goal>revision</goal>
+						</goals>
+						<phase>initialize</phase>
+						<configuration>
+							<dotGitDirectory>${project.basedir}/metaschema/.git</dotGitDirectory>
+							<prefix>metaschema-git</prefix>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>templating-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>filter-src</id>
+						<goals>
+							<goal>filter-sources</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/metaschema-model/src/main/java-templates/gov/nist/secauto/metaschema/model/MetaschemaVersion.java
+++ b/metaschema-model/src/main/java-templates/gov/nist/secauto/metaschema/model/MetaschemaVersion.java
@@ -1,0 +1,69 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.model;
+
+import gov.nist.secauto.metaschema.model.common.util.IVersionInfo;
+
+public class MetaschemaVersion implements IVersionInfo {
+
+  public static final String NAME = "Metaschema";
+  public static final String BUILD_VERSION = "${project.version}";
+  public static final String BUILD_TIMESTAMP = "${timestamp}";
+  public static final String COMMIT = "@metaschema-git.commit.id.abbrev@";
+  public static final String BRANCH = "@metaschema-git.branch@";
+  public static final String CLOSEST_TAG = "@metaschema-git.closest.tag.name@";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public String getVersion() {
+    return CLOSEST_TAG;
+  }
+
+  @Override
+  public String getBuildTimestamp() {
+    return BUILD_TIMESTAMP;
+  }
+
+  @Override
+  public String getGitCommit() {
+    return COMMIT;
+  }
+
+  @Override
+  public String getGitBranch() {
+    return BRANCH;
+  }
+
+  @Override
+  public String getGitClosestTag() {
+    return CLOSEST_TAG;
+  }
+}

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/AbstractSchemaGenerator.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/AbstractSchemaGenerator.java
@@ -101,9 +101,12 @@ public abstract class AbstractSchemaGenerator<T extends AutoCloseable, D extends
       Writer out,
       IConfiguration<SchemaGenerationFeature> configuration) {
     // IInlineStrategy inlineStrategy = IInlineStrategy.newInlineStrategy(configuration);
-    try (T schemaWriter = newWriter(out)) {
+    try  {
+      // avoid automatically closing streams not owned by the generator
+      T schemaWriter = newWriter(out);
       S generationState = newGenerationState(metaschema, schemaWriter, configuration);
       generateSchema(generationState);
+      generationState.flushWriter();
     } catch (SchemaGenerationException ex) { // NOPMD avoid nesting same exception
       throw ex;
     } catch (Exception ex) { // NOPMD need to catch close exception

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/IGenerationState.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/IGenerationState.java
@@ -29,6 +29,8 @@ package gov.nist.secauto.metaschema.schemagen;
 import gov.nist.secauto.metaschema.model.common.IDefinition;
 import gov.nist.secauto.metaschema.model.common.IMetaschema;
 
+import java.io.IOException;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public interface IGenerationState<WRITER> {
@@ -39,6 +41,8 @@ public interface IGenerationState<WRITER> {
   WRITER getWriter();
 
   boolean isInline(@NonNull IDefinition definition);
+  
+  void flushWriter() throws IOException;
   //
   // @NonNull
   // String getTypeNameForDefinition(@NonNull IDefinition definition);

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/json/JsonGenerationState.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/json/JsonGenerationState.java
@@ -180,4 +180,9 @@ public class JsonGenerationState
     writer.writeFieldName(fieldName);
     writer.writeTree(obj);
   }
+
+  @Override
+  public void flushWriter() throws IOException {
+    getWriter().flush();
+  }
 }

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/json/JsonSchemaGenerator.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/json/JsonSchemaGenerator.java
@@ -28,6 +28,7 @@ package gov.nist.secauto.metaschema.schemagen.json;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonGenerator.Feature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -74,7 +75,8 @@ public class JsonSchemaGenerator
     try {
       return ObjectUtils.notNull(getJsonFactory().createGenerator(out)
           .setCodec(new ObjectMapper())
-          .useDefaultPrettyPrinter());
+          .useDefaultPrettyPrinter()
+          .disable(Feature.AUTO_CLOSE_TARGET));
     } catch (IOException ex) {
       throw new SchemaGenerationException(ex);
     }

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/xml/XmlGenerationState.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/xml/XmlGenerationState.java
@@ -53,6 +53,7 @@ import gov.nist.secauto.metaschema.schemagen.xml.schematype.XmlSimpleTypeUnion;
 
 import org.codehaus.stax2.XMLStreamWriter2;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -274,4 +275,15 @@ public class XmlGenerationState
   public void writeNamespace(String prefix, String namespaceUri) throws XMLStreamException {
     getXMLStreamWriter().writeNamespace(prefix, namespaceUri);
   }
-}
+
+  @Override
+  public void flushWriter() throws IOException {
+    try {
+      getWriter().getResource().flush();
+    } catch (XMLStreamException ex) {
+      throw new IOException(ex);
+    }
+  }
+  }
+
+  

--- a/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/AbstractSchemaGeneratorTestSuite.java
+++ b/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/AbstractSchemaGeneratorTestSuite.java
@@ -116,7 +116,7 @@ public abstract class AbstractSchemaGeneratorTestSuite
     JSON_SCHEMA_PROVIDER = jsonProvider;
 
     try (InputStream is = MetaschemaLoader.class.getResourceAsStream("/schema/json/json-schema.json")) {
-      assert is != null;
+      assert is != null : "unable to get JSON schema resource";
       JsonSchemaContentValidator schemaValidator = new JsonSchemaContentValidator(is);
       JSON_SCHEMA_VALIDATOR = schemaValidator;
     } catch (IOException ex) {

--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,12 @@
 
 		<mojo.maven.version>3.9.3</mojo.maven.version>
 
+		<timestamp>${maven.build.timestamp}</timestamp>
+		<maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
+
 		<dependency.antlr4.version>4.10.1</dependency.antlr4.version>
 		<dependency.auto-service.version>1.0.1</dependency.auto-service.version>
+		<dependency.commons-cli.version>1.5.0</dependency.commons-cli.version>
 		<dependency.commons-collections4.version>4.4</dependency.commons-collections4.version>
 		<dependency.commons-io.version>2.13.0</dependency.commons-io.version>
 		<dependency.commons-lang3.version>3.12.0</dependency.commons-lang3.version>
@@ -126,6 +130,7 @@
 		<dependency.inject-resources-junit-jupiter.version>0.3.3</dependency.inject-resources-junit-jupiter.version>
 		<dependency.jackson.version>2.13.3</dependency.jackson.version>
 		<dependency.jackson-databind.version>2.13.4</dependency.jackson-databind.version>
+		<dependency.jansi.version>2.4.0</dependency.jansi.version>
 		<dependency.jaxb.version>4.0.0</dependency.jaxb.version>
 		<dependency.jaxb-api.version>2.3.1</dependency.jaxb-api.version>
 		<dependency.jaxen.version>2.0.0</dependency.jaxen.version>
@@ -149,10 +154,14 @@
 		<dependency.xml-apis.version>2.0.2</dependency.xml-apis.version>
 
 		<plugin.antlr4test.version>1.22</plugin.antlr4test.version>
+		<plugin.appassembler.version>2.1.0</plugin.appassembler.version>
+		<plugin.git-commit-id.version>5.0.0</plugin.git-commit-id.version>
 		<plugin.maven-changes.version>2.12.1</plugin.maven-changes.version>
 		<plugin.maven-dependency.version>3.6.0</plugin.maven-dependency.version>
 		<plugin.maven-invoker.version>3.6.0</plugin.maven-invoker.version>
+		<plugin.maven-surefire.version>3.1.2</plugin.maven-surefire.version>
 		<plugin.spotbugs.version>4.7.3.4</plugin.spotbugs.version>
+		<plugin.templating.version>1.0.0</plugin.templating.version>
 	</properties>
 	<repositories>
 		<repository>
@@ -222,6 +231,11 @@
 			<dependency>
 				<groupId>${project.groupId}</groupId>
 				<artifactId>metaschema-testing</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>${project.groupId}</groupId>
+				<artifactId>cli-processor</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
@@ -409,6 +423,11 @@
 				<version>5.4.0</version>
 			</dependency>
 			<dependency>
+				<groupId>org.fusesource.jansi</groupId>
+				<artifactId>jansi</artifactId>
+				<version>${dependency.jansi.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-core</artifactId>
 				<version>${dependency.log4j2.version}</version>
@@ -444,6 +463,11 @@
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-text</artifactId>
 				<version>${dependency.commons-text.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-cli</groupId>
+				<artifactId>commons-cli</artifactId>
+				<version>${dependency.commons-cli.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>
@@ -628,6 +652,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
+					<version>${plugin.maven-surefire.version}</version>
 					<configuration>
 						<forkCount>1.5C</forkCount>
 						<reuseForks>true</reuseForks>
@@ -670,6 +695,26 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-invoker-plugin</artifactId>
 					<version>${plugin.maven-invoker.version}</version>
+				</plugin>
+				<plugin>
+					<groupId>io.github.git-commit-id</groupId>
+					<artifactId>git-commit-id-maven-plugin</artifactId>
+					<version>${plugin.git-commit-id.version}</version>
+					<configuration>
+						<dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+						<verbose>true</verbose>
+						<useNativeGit>false</useNativeGit>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>templating-maven-plugin</artifactId>
+					<version>${plugin.templating.version}</version>
+				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>appassembler-maven-plugin</artifactId>
+					<version>${plugin.appassembler.version}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -829,5 +874,7 @@
 		<module>metaschema-schema-generator</module>
 		<!-- <module>metaschema-documentation-generator</module> -->
 		<module>metaschema-testing</module>
+		<module>cli-processor</module>
+		<module>metaschema-cli</module>
 	</modules>
 </project>


### PR DESCRIPTION
# Committer Notes

Migrate the CLI framework [from oscal-cli](https://github.com/usnistgov/oscal-cli/tree/main/cli-framework) to a metaschema-java module to allow for easy creation of command line tools based on metaschema-java.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
