### PR TITLE
Properly handle whitespace with HTML tags

### DIFF
--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/markup/MarkupMultiline.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/markup/MarkupMultiline.java
@@ -35,6 +35,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class MarkupMultiline
     extends AbstractMarkupString<MarkupMultiline> {
 
+  @NonNull
+  private static final FlexmarkFactory FLEXMARK_FACTORY = FlexmarkFactory.instance();
+
   /**
    * Convert the provided HTML string into markup.
    *
@@ -47,8 +50,8 @@ public class MarkupMultiline
     return new MarkupMultiline(
         parseHtml(
             html,
-            FlexmarkFactory.instance().getFlexmarkHtmlConverter(),
-            FlexmarkFactory.instance().getMarkdownParser()));
+            FLEXMARK_FACTORY.getFlexmarkHtmlConverter(),
+            FLEXMARK_FACTORY.getMarkdownParser()));
   }
 
   /**
@@ -61,7 +64,7 @@ public class MarkupMultiline
   @NonNull
   public static MarkupMultiline fromMarkdown(@NonNull String markdown) {
     return new MarkupMultiline(
-        parseMarkdown(markdown, FlexmarkFactory.instance().getMarkdownParser()));
+        parseMarkdown(markdown, FLEXMARK_FACTORY.getMarkdownParser()));
   }
 
   /**
@@ -76,7 +79,7 @@ public class MarkupMultiline
 
   @Override
   public FlexmarkFactory getFlexmarkFactory() {
-    return FlexmarkFactory.instance();
+    return FLEXMARK_FACTORY;
   }
 
   @Override

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/markup/flexmark/FlexmarkFactory.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/datatype/markup/flexmark/FlexmarkFactory.java
@@ -63,8 +63,9 @@ public class FlexmarkFactory {
 
   public FlexmarkFactory(@NonNull DataHolder config) {
     this.configuration = config;
-    this.markdownParser = Parser.builder(config).customDelimiterProcessor(
-        new FixedEmphasisDelimiterProcessor(Parser.STRONG_WRAPS_EMPHASIS.get(config))).build();
+    this.markdownParser = Parser.builder(config)
+        .customDelimiterProcessor(new FixedEmphasisDelimiterProcessor(Parser.STRONG_WRAPS_EMPHASIS.get(config)))
+        .build();
     this.htmlRenderer = HtmlRenderer.builder(config).build();
     this.formatter = Formatter.builder(config).build();
     this.htmlConverter = FlexmarkHtmlConverter.builder(config).build();

--- a/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/datatype/markup/MarkupStringTest.java
+++ b/metaschema-model-common/src/test/java/gov/nist/secauto/metaschema/model/common/datatype/markup/MarkupStringTest.java
@@ -26,6 +26,7 @@
 
 package gov.nist.secauto.metaschema.model.common.datatype.markup;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -34,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.ctc.wstx.api.WstxOutputProperties;
 import com.ctc.wstx.stax.WstxOutputFactory;
 import com.vladsch.flexmark.ast.Emphasis;
+import com.vladsch.flexmark.ast.Heading;
 import com.vladsch.flexmark.ast.Paragraph;
 import com.vladsch.flexmark.ast.StrongEmphasis;
 import com.vladsch.flexmark.ast.Text;
@@ -46,6 +48,7 @@ import gov.nist.secauto.metaschema.model.common.datatype.markup.flexmark.AstColl
 import gov.nist.secauto.metaschema.model.common.datatype.markup.flexmark.InsertAnchorExtension.InsertAnchorNode;
 import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
 
+import org.apache.commons.collections.IteratorUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codehaus.stax2.XMLOutputFactory2;
@@ -152,7 +155,8 @@ class MarkupStringTest {
       }
       // InsertAnchorNode[0, 0] name:[39, 45, "insert"]
       {
-        @SuppressWarnings("unused") InsertAnchorNode insert = (InsertAnchorNode) paragraphChildren.get(5);
+        @SuppressWarnings("unused")
+        InsertAnchorNode insert = (InsertAnchorNode) paragraphChildren.get(5);
       }
       // Text[48, 49] chars:[48, 49, "."]
       {
@@ -373,5 +377,27 @@ class MarkupStringTest {
     LOGGER.atInfo().log("HTML: {}", ms.toHtml());
     LOGGER.atInfo().log("Markdown: {}", ms.toMarkdown());
 
+  }
+
+  @Test
+  void testIntraTagNewline() {
+    // addresses usnistgov/liboscal-java#5
+    String html = 
+        "<h1>A custom title\n" +
+        "  <em>with italic</em>\n" +
+        "</h1>";
+    MarkupMultiline ms = MarkupMultiline.fromHtml(html);
+
+    Document doc = ms.getDocument();
+    LOGGER.atInfo().log("AST: {}", AstCollectingVisitor.asString(doc));
+    LOGGER.atInfo().log("HTML: {}", ms.toHtml());
+    LOGGER.atInfo().log("Markdown: {}", ms.toMarkdown());
+
+    List<Node> children = CollectionUtil.toList(doc.getChildren());
+    // ensure there is only 1 child and that it is a heading
+    assertAll(
+        () -> assertEquals(1, children.size()),
+        () -> assertEquals(Heading.class, children.get(0).getClass())
+    );
   }
 }


### PR DESCRIPTION
# Committer Notes

Fixed issue caused by a newline within an HTML tag that caused the resulting markdown to erroneously also include the same newline.

This change normalizes spacing within non `<pre>` HTML text nodes to ensure that newlines do not end up in the Markdown.

Resolves usnistgov/liboscal-java#5.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
