### PR TITLE
Add support for yaml nulls

### DIFF
--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/model/ListPropertyInfo.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/model/ListPropertyInfo.java
@@ -142,6 +142,8 @@ class ListPropertyInfo
       // // read the object's END_OBJECT
       // JsonUtil.assertAndAdvance(context.getReader(), JsonToken.END_OBJECT);
       // }
+    } else if (JsonToken.VALUE_NULL.equals(parser.currentToken())) {
+      JsonUtil.assertAndAdvance(parser, JsonToken.VALUE_NULL);
     } else {
       // this is an array, we need to parse the array wrapper then each item
       JsonUtil.assertAndAdvance(parser, JsonToken.START_ARRAY);


### PR DESCRIPTION
# Committer Notes

Added support for YAML null values: `~` or `null`.

This issue was raised by usnistgov/oscal-cli#84.

Resolves #157.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
