### PR TITLE
Set 2GB SnakeYaml codepoint limit

### DIFF
--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
@@ -189,8 +189,7 @@ public class GenerateSchemaCommand
     String asFormatText = cmdLine.getOptionValue(AS_OPTION);
     SchemaFormat asFormat = SchemaFormat.valueOf(asFormatText.toUpperCase(Locale.ROOT));
 
-    IMutableConfiguration<SchemaGenerationFeature> configuration
-        = new DefaultConfiguration<>(SchemaGenerationFeature.class);
+    IMutableConfiguration<SchemaGenerationFeature<?>> configuration = new DefaultConfiguration<>();
     if (cmdLine.hasOption(INLINE_TYPES_OPTION)) {
       configuration.enableFeature(SchemaGenerationFeature.INLINE_DEFINITIONS);
       if (SchemaFormat.JSON.equals(asFormat)) {

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/AbstractDeserializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/AbstractDeserializer.java
@@ -28,6 +28,8 @@ package gov.nist.secauto.metaschema.binding.io;
 
 import gov.nist.secauto.metaschema.binding.IBindingContext;
 import gov.nist.secauto.metaschema.binding.model.IAssemblyClassBinding;
+import gov.nist.secauto.metaschema.model.common.configuration.IConfiguration;
+import gov.nist.secauto.metaschema.model.common.configuration.IMutableConfiguration;
 import gov.nist.secauto.metaschema.model.common.constraint.DefaultConstraintValidator;
 import gov.nist.secauto.metaschema.model.common.constraint.IConstraintValidationHandler;
 import gov.nist.secauto.metaschema.model.common.constraint.LoggingConstraintValidationHandler;
@@ -49,7 +51,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  *          the bound class to deserialize to
  */
 public abstract class AbstractDeserializer<CLASS>
-    extends AbstractSerializationBase<DeserializationFeature>
+    extends AbstractSerializationBase<DeserializationFeature<?>>
     implements IDeserializer<CLASS> {
 
   private IConstraintValidationHandler constraintValidationHandler;
@@ -63,7 +65,7 @@ public abstract class AbstractDeserializer<CLASS>
    *          the bound class information for the Java type this deserializer is operating on
    */
   protected AbstractDeserializer(@NonNull IBindingContext bindingContext, @NonNull IAssemblyClassBinding classBinding) {
-    super(bindingContext, classBinding, DeserializationFeature.class);
+    super(bindingContext, classBinding);
   }
 
   @Override
@@ -120,4 +122,31 @@ public abstract class AbstractDeserializer<CLASS>
   @NonNull
   protected abstract INodeItem deserializeToNodeItemInternal(@NonNull Reader reader, @NonNull URI documentUri)
       throws IOException;
+
+  @Override
+  public IDeserializer<CLASS> enableFeature(DeserializationFeature<?> feature) {
+    return set(feature, true);
+  }
+
+  @Override
+  public IDeserializer<CLASS> disableFeature(DeserializationFeature<?> feature) {
+    return set(feature, false);
+  }
+
+  @Override
+  public IDeserializer<CLASS> applyConfiguration(
+      @NonNull IConfiguration<DeserializationFeature<?>> other) {
+    IMutableConfiguration<DeserializationFeature<?>> config = getConfiguration();
+    config.applyConfiguration(other);
+    configurationChanged(config);
+    return this;
+  }
+
+  @Override
+  public IDeserializer<CLASS> set(DeserializationFeature<?> feature, Object value) {
+    IMutableConfiguration<DeserializationFeature<?>> config = getConfiguration();
+    config.set(feature, value);
+    configurationChanged(config);
+    return this;
+  }
 }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/AbstractSerializationBase.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/AbstractSerializationBase.java
@@ -29,17 +29,16 @@ package gov.nist.secauto.metaschema.binding.io;
 import gov.nist.secauto.metaschema.binding.IBindingContext;
 import gov.nist.secauto.metaschema.binding.model.IAssemblyClassBinding;
 import gov.nist.secauto.metaschema.model.common.configuration.DefaultConfiguration;
-import gov.nist.secauto.metaschema.model.common.configuration.IConfiguration;
 import gov.nist.secauto.metaschema.model.common.configuration.IConfigurationFeature;
 import gov.nist.secauto.metaschema.model.common.configuration.IMutableConfiguration;
 import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 
-import java.util.Set;
+import java.util.Map;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 @SuppressWarnings("PMD.ReplaceVectorWithList") // false positive
-abstract class AbstractSerializationBase<T extends Enum<T> & IConfigurationFeature>
+abstract class AbstractSerializationBase<T extends IConfigurationFeature<?>>
     implements IMutableConfiguration<T> {
   @NonNull
   private final IBindingContext bindingContext;
@@ -48,11 +47,12 @@ abstract class AbstractSerializationBase<T extends Enum<T> & IConfigurationFeatu
   @NonNull
   private final DefaultConfiguration<T> configuration;
 
-  protected AbstractSerializationBase(@NonNull IBindingContext bindingContext,
-      @NonNull IAssemblyClassBinding classBinding, @NonNull Class<T> configurationEnum) {
+  protected AbstractSerializationBase(
+      @NonNull IBindingContext bindingContext,
+      @NonNull IAssemblyClassBinding classBinding) {
     this.bindingContext = ObjectUtils.requireNonNull(bindingContext, "bindingContext");
     this.classBinding = ObjectUtils.requireNonNull(classBinding, "classBinding");
-    this.configuration = new DefaultConfiguration<>(configurationEnum);
+    this.configuration = new DefaultConfiguration<>();
   }
 
   /**
@@ -76,24 +76,19 @@ abstract class AbstractSerializationBase<T extends Enum<T> & IConfigurationFeatu
     return classBinding;
   }
 
+  @SuppressWarnings("unused")
+  protected void configurationChanged(@NonNull IMutableConfiguration<T> config) {
+    // do nothing by default. Methods can override this to deal with factory caching
+  }
+
   /**
    * Get the current configuration of the serializer/deserializer.
    *
    * @return the configuration
    */
   @NonNull
-  protected IConfiguration<T> getConfiguration() {
+  protected IMutableConfiguration<T> getConfiguration() {
     return configuration;
-  }
-
-  @Override
-  public IMutableConfiguration<T> enableFeature(T feature) {
-    return configuration.enableFeature(feature);
-  }
-
-  @Override
-  public IMutableConfiguration<T> disableFeature(T feature) {
-    return configuration.disableFeature(feature);
   }
 
   @Override
@@ -102,13 +97,13 @@ abstract class AbstractSerializationBase<T extends Enum<T> & IConfigurationFeatu
   }
 
   @Override
-  public Set<T> getFeatureSet() {
-    return configuration.getFeatureSet();
+  public Map<T, Object> getFeatureValues() {
+    return configuration.getFeatureValues();
   }
 
   @Override
-  public IMutableConfiguration<T>
-      applyConfiguration(@NonNull IConfiguration<T> other) {
-    return configuration.applyConfiguration(other);
+  public <V> V get(T feature) {
+    return configuration.get(feature);
   }
+
 }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/AbstractSerializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/AbstractSerializer.java
@@ -28,6 +28,8 @@ package gov.nist.secauto.metaschema.binding.io;
 
 import gov.nist.secauto.metaschema.binding.IBindingContext;
 import gov.nist.secauto.metaschema.binding.model.IAssemblyClassBinding;
+import gov.nist.secauto.metaschema.model.common.configuration.IConfiguration;
+import gov.nist.secauto.metaschema.model.common.configuration.IMutableConfiguration;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -38,7 +40,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  *          the bound class to serialize from
  */
 public abstract class AbstractSerializer<CLASS>
-    extends AbstractSerializationBase<SerializationFeature>
+    extends AbstractSerializationBase<SerializationFeature<?>>
     implements ISerializer<CLASS> {
 
   /**
@@ -49,7 +51,36 @@ public abstract class AbstractSerializer<CLASS>
    * @param classBinding
    *          the bound class information for the Java type this serializer is operating on
    */
-  public AbstractSerializer(@NonNull IBindingContext bindingContext, @NonNull IAssemblyClassBinding classBinding) {
-    super(bindingContext, classBinding, SerializationFeature.class);
+  public AbstractSerializer(
+      @NonNull IBindingContext bindingContext,
+      @NonNull IAssemblyClassBinding classBinding) {
+    super(bindingContext, classBinding);
+  }
+
+  @Override
+  public ISerializer<CLASS> enableFeature(SerializationFeature<?> feature) {
+    return set(feature, true);
+  }
+
+  @Override
+  public ISerializer<CLASS> disableFeature(SerializationFeature<?> feature) {
+    return set(feature, false);
+  }
+
+  @Override
+  public ISerializer<CLASS> applyConfiguration(
+      @NonNull IConfiguration<SerializationFeature<?>> other) {
+    IMutableConfiguration<SerializationFeature<?>> config = getConfiguration();
+    config.applyConfiguration(other);
+    configurationChanged(config);
+    return this;
+  }
+
+  @Override
+  public ISerializer<CLASS> set(SerializationFeature<?> feature, Object value) {
+    IMutableConfiguration<SerializationFeature<?>> config = getConfiguration();
+    config.set(feature, value);
+    configurationChanged(config);
+    return this;
   }
 }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/DeserializationFeature.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/DeserializationFeature.java
@@ -27,28 +27,41 @@
 package gov.nist.secauto.metaschema.binding.io;
 
 import gov.nist.secauto.metaschema.model.common.IAssemblyDefinition;
-import gov.nist.secauto.metaschema.model.common.configuration.IConfigurationFeature;
+import gov.nist.secauto.metaschema.model.common.configuration.AbstractConfigurationFeature;
 
-public enum DeserializationFeature implements IConfigurationFeature {
+import org.yaml.snakeyaml.Yaml;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public final class DeserializationFeature<V>
+    extends AbstractConfigurationFeature<V> {
+  public static final int YAML_CODEPOINT_LIMIT_DEFAULT =  2 * 1024 * 1024 * 1024; // 2 GB
+
   /**
    * If enabled, perform constraint validation on the deserialized bound objects.
    */
-  DESERIALIZE_VALIDATE_CONSTRAINTS(true),
+  @NonNull
+  public static final DeserializationFeature<Boolean> DESERIALIZE_VALIDATE_CONSTRAINTS
+      = new DeserializationFeature<>(Boolean.class, true);
+
   /**
    * If enabled, process the next JSON node as a field, whose name must match the
    * {@link IAssemblyDefinition#getRootJsonName()}. If not enabled, the next JSON node is expected to
    * be an object containing the data of the {@link IAssemblyDefinition}.
    */
-  DESERIALIZE_JSON_ROOT_PROPERTY(true);
+  public static final DeserializationFeature<Boolean> DESERIALIZE_JSON_ROOT_PROPERTY
+      = new DeserializationFeature<>(Boolean.class, true);
 
-  private final boolean enabledByDefault;
+  /**
+   * If enabled, perform constraint validation on the deserialized bound objects.
+   */
+  @NonNull
+  public static final DeserializationFeature<Integer> YAML_CODEPOINT_LIMIT
+      = new DeserializationFeature<>(Integer.class, YAML_CODEPOINT_LIMIT_DEFAULT);
 
-  DeserializationFeature(boolean enabled) {
-    this.enabledByDefault = enabled;
-  }
-
-  @Override
-  public boolean isEnabledByDefault() {
-    return enabledByDefault;
+  private DeserializationFeature(
+      @NonNull Class<V> valueClass,
+      @NonNull V defaultValue) {
+    super(valueClass, defaultValue);
   }
 }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/IBoundLoader.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/IBoundLoader.java
@@ -28,6 +28,7 @@ package gov.nist.secauto.metaschema.binding.io;
 
 import gov.nist.secauto.metaschema.binding.DefaultBindingContext;
 import gov.nist.secauto.metaschema.binding.IBindingContext;
+import gov.nist.secauto.metaschema.model.common.configuration.IConfiguration;
 import gov.nist.secauto.metaschema.model.common.configuration.IMutableConfiguration;
 import gov.nist.secauto.metaschema.model.common.metapath.IDocumentLoader;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
@@ -50,7 +51,20 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * A common interface for loading Metaschema based instance resources.
  */
-public interface IBoundLoader extends IDocumentLoader, IMutableConfiguration<DeserializationFeature> {
+public interface IBoundLoader extends IDocumentLoader, IMutableConfiguration<DeserializationFeature<?>> {
+
+  @Override
+  IBoundLoader enableFeature(DeserializationFeature<?> feature);
+
+  @Override
+  IBoundLoader disableFeature(DeserializationFeature<?> feature);
+
+  @Override
+  IBoundLoader applyConfiguration(IConfiguration<DeserializationFeature<?>> other);
+
+  @Override
+  IBoundLoader set(DeserializationFeature<?> feature, Object value);
+
   /**
    * Determine the format of the provided resource.
    *

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/IDeserializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/IDeserializer.java
@@ -26,6 +26,7 @@
 
 package gov.nist.secauto.metaschema.binding.io;
 
+import gov.nist.secauto.metaschema.model.common.configuration.IConfiguration;
 import gov.nist.secauto.metaschema.model.common.configuration.IMutableConfiguration;
 import gov.nist.secauto.metaschema.model.common.constraint.IConstraintValidationHandler;
 import gov.nist.secauto.metaschema.model.common.metapath.item.INodeItem;
@@ -52,7 +53,20 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param <CLASS>
  *          the Java type into which data can be read
  */
-public interface IDeserializer<CLASS> extends IMutableConfiguration<DeserializationFeature> {
+public interface IDeserializer<CLASS> extends IMutableConfiguration<DeserializationFeature<?>> {
+
+  @Override
+  IDeserializer<CLASS> enableFeature(DeserializationFeature<?> feature);
+
+  @Override
+  IDeserializer<CLASS> disableFeature(DeserializationFeature<?> feature);
+
+  @Override
+  IDeserializer<CLASS> applyConfiguration(IConfiguration<DeserializationFeature<?>> other);
+
+  @Override
+  IDeserializer<CLASS> set(DeserializationFeature<?> feature, Object value);
+
   /**
    * Determine if the serializer is performing validation.
    *

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/ISerializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/ISerializer.java
@@ -26,6 +26,7 @@
 
 package gov.nist.secauto.metaschema.binding.io;
 
+import gov.nist.secauto.metaschema.model.common.configuration.IConfiguration;
 import gov.nist.secauto.metaschema.model.common.configuration.IMutableConfiguration;
 import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 
@@ -49,7 +50,20 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param <CLASS>
  *          the Java type from which data can be written
  */
-public interface ISerializer<CLASS> extends IMutableConfiguration<SerializationFeature> {
+public interface ISerializer<CLASS> extends IMutableConfiguration<SerializationFeature<?>> {
+
+  @Override
+  ISerializer<CLASS> enableFeature(SerializationFeature<?> feature);
+
+  @Override
+  ISerializer<CLASS> disableFeature(SerializationFeature<?> feature);
+
+  @Override
+  ISerializer<CLASS> applyConfiguration(IConfiguration<SerializationFeature<?>> other);
+
+  @Override
+  ISerializer<CLASS> set(SerializationFeature<?> feature, Object value);
+
   /**
    * Write data from a bound class instance to the {@link OutputStream}.
    * <p>

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/SerializationFeature.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/SerializationFeature.java
@@ -26,24 +26,25 @@
 
 package gov.nist.secauto.metaschema.binding.io;
 
-import gov.nist.secauto.metaschema.model.common.configuration.IConfigurationFeature;
+import gov.nist.secauto.metaschema.model.common.configuration.AbstractConfigurationFeature;
 
-public enum SerializationFeature implements IConfigurationFeature {
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public final class SerializationFeature<V>
+    extends AbstractConfigurationFeature<V> {
   /**
    * If enabled, generate document level constructs in the underlying data format. In XML this would
    * include XML declarations. In JSON or YAML, this would include an outer object and field with the
    * name associated with the root node.
    */
-  SERIALIZE_ROOT(true);
+  @NonNull
+  public static final SerializationFeature<Boolean> SERIALIZE_ROOT
+      = new SerializationFeature<>(Boolean.class, true);
 
-  private final boolean enabledByDefault;
-
-  SerializationFeature(boolean enabled) {
-    this.enabledByDefault = enabled;
+  private SerializationFeature(
+      @NonNull Class<V> valueClass,
+      @NonNull V defaultValue) {
+    super(valueClass, defaultValue);
   }
 
-  @Override
-  public boolean isEnabledByDefault() {
-    return enabledByDefault;
-  }
 }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/DefaultJsonDeserializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/DefaultJsonDeserializer.java
@@ -77,11 +77,7 @@ public class DefaultJsonDeserializer<CLASS>
 
   @NonNull
   protected JsonParser newJsonParser(@NonNull Reader reader) throws IOException {
-    JsonParser retval = getJsonFactory().createParser(reader);
-    // avoid automatically closing streams not owned by the parser
-    retval.configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, false);
-    return retval;
-
+    return ObjectUtils.notNull(getJsonFactory().createParser(reader));
   }
 
   @SuppressWarnings("null")
@@ -92,14 +88,15 @@ public class DefaultJsonDeserializer<CLASS>
     try (JsonParser parser = newJsonParser(reader)) {
       DefaultJsonParsingContext parsingContext = new DefaultJsonParsingContext(parser, new DefaultJsonProblemHandler());
       IAssemblyClassBinding classBinding = getClassBinding();
-      IConfiguration<DeserializationFeature> configuration = getConfiguration();
+      IConfiguration<DeserializationFeature<?>> configuration = getConfiguration();
 
       if (classBinding.isRoot()
           && configuration.isFeatureEnabled(DeserializationFeature.DESERIALIZE_JSON_ROOT_PROPERTY)) {
 
         RootAssemblyDefinition root = new RootAssemblyDefinition(classBinding);
         // now parse the root property
-        @SuppressWarnings("unchecked") CLASS value = ObjectUtils.requireNonNull((CLASS) root.readRoot(parsingContext));
+        @SuppressWarnings("unchecked")
+        CLASS value = ObjectUtils.requireNonNull((CLASS) root.readRoot(parsingContext));
 
         // // we should be at the end object
         // JsonUtil.assertCurrent(parser, JsonToken.END_OBJECT);
@@ -109,7 +106,8 @@ public class DefaultJsonDeserializer<CLASS>
 
         retval = DefaultNodeItemFactory.instance().newDocumentNodeItem(root, value, documentUri);
       } else {
-        @SuppressWarnings("unchecked") CLASS value
+        @SuppressWarnings("unchecked")
+        CLASS value
             = ObjectUtils.requireNonNull((CLASS) classBinding.readObject(parsingContext));
         retval = DefaultNodeItemFactory.instance().newAssemblyNodeItem(classBinding, value, documentUri);
       }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/DefaultJsonSerializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/DefaultJsonSerializer.java
@@ -32,8 +32,10 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 
 import gov.nist.secauto.metaschema.binding.IBindingContext;
 import gov.nist.secauto.metaschema.binding.io.AbstractSerializer;
+import gov.nist.secauto.metaschema.binding.io.SerializationFeature;
 import gov.nist.secauto.metaschema.binding.model.IAssemblyClassBinding;
 import gov.nist.secauto.metaschema.binding.model.RootAssemblyDefinition;
+import gov.nist.secauto.metaschema.model.common.configuration.IMutableConfiguration;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -51,6 +53,13 @@ public class DefaultJsonSerializer<CLASS>
   @NonNull
   protected JsonFactory getJsonFactoryInstance() {
     return JsonFactoryFactory.instance();
+  }
+
+  @Override
+  protected void configurationChanged(IMutableConfiguration<SerializationFeature<?>> config) {
+    synchronized (this) {
+      jsonFactory = null;
+    }
   }
 
   @NonNull
@@ -74,8 +83,6 @@ public class DefaultJsonSerializer<CLASS>
   protected JsonGenerator newJsonGenerator(@NonNull Writer writer) throws IOException {
     JsonFactory factory = getJsonFactory();
     JsonGenerator retval = factory.createGenerator(writer);
-    // avoid automatically closing streams not owned by the generator
-    retval.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
     retval.setPrettyPrinter(new DefaultPrettyPrinter());
     return retval;
   }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/JsonFactoryFactory.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/json/JsonFactoryFactory.java
@@ -42,8 +42,7 @@ public final class JsonFactoryFactory {
   @NonNull
   public static JsonFactory newJsonFactoryInstance() {
     JsonFactory retval = new JsonFactory();
-    // avoid automatically closing streams not owned by the reader
-    retval.disable(Feature.AUTO_CLOSE_SOURCE);
+    configureJsonFactory(retval);
     return retval;
   }
 
@@ -52,4 +51,8 @@ public final class JsonFactoryFactory {
     return SINGLETON;
   }
 
+  public static void configureJsonFactory(@NonNull JsonFactory factory) {
+    // avoid automatically closing streams not owned by the reader
+    factory.disable(Feature.AUTO_CLOSE_SOURCE);
+  }
 }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/DefaultYamlDeserializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/DefaultYamlDeserializer.java
@@ -26,12 +26,11 @@
 
 package gov.nist.secauto.metaschema.binding.io.yaml;
 
-import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import gov.nist.secauto.metaschema.binding.IBindingContext;
 import gov.nist.secauto.metaschema.binding.io.json.DefaultJsonDeserializer;
 import gov.nist.secauto.metaschema.binding.model.IAssemblyClassBinding;
-import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -48,8 +47,8 @@ public class DefaultYamlDeserializer<CLASS>
   // }
 
   @Override
-  protected JsonFactory getJsonFactoryInstance() {
-    return ObjectUtils.notNull(YamlFactoryFactory.instance());
+  protected YAMLFactory getJsonFactoryInstance() {
+    return YamlFactoryFactory.newParserFactoryInstance(getConfiguration());
   }
 
 }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/DefaultYamlSerializer.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/DefaultYamlSerializer.java
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.core.JsonFactory;
 import gov.nist.secauto.metaschema.binding.IBindingContext;
 import gov.nist.secauto.metaschema.binding.io.json.DefaultJsonSerializer;
 import gov.nist.secauto.metaschema.binding.model.IAssemblyClassBinding;
-import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -44,7 +43,6 @@ public class DefaultYamlSerializer<CLASS>
 
   @Override
   protected JsonFactory getJsonFactoryInstance() {
-    return ObjectUtils.notNull(YamlFactoryFactory.instance());
+    return YamlFactoryFactory.newGeneratorFactoryInstance(getConfiguration());
   }
-
 }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/YamlFactoryFactory.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/YamlFactoryFactory.java
@@ -26,40 +26,54 @@
 
 package gov.nist.secauto.metaschema.binding.io.yaml;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 
+import gov.nist.secauto.metaschema.binding.io.DeserializationFeature;
+import gov.nist.secauto.metaschema.binding.io.SerializationFeature;
+import gov.nist.secauto.metaschema.binding.io.json.JsonFactoryFactory;
+import gov.nist.secauto.metaschema.model.common.configuration.IMutableConfiguration;
+import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
+
 import org.yaml.snakeyaml.LoaderOptions;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 public final class YamlFactoryFactory {
-  public static final int CODEPOINT_LIMIT = 2 * 1024 * 1024 * 1024; // 2 GB
-
-  private static final YAMLFactory SINGLETON = newYamlFactoryInstance();
-
   private YamlFactoryFactory() {
     // disable construction
   }
 
-  public static YAMLFactory newYamlFactoryInstance() {
+  @NonNull
+  public static YAMLFactory newParserFactoryInstance(@NonNull IMutableConfiguration<DeserializationFeature<?>> config) {
     YAMLFactoryBuilder builder = YAMLFactory.builder();
     LoaderOptions loaderOptions = builder.loaderOptions();
     if (loaderOptions == null) {
       loaderOptions = new LoaderOptions();
     }
-    loaderOptions.setCodePointLimit(CODEPOINT_LIMIT);
+
+    int codePointLimit = config.get(DeserializationFeature.YAML_CODEPOINT_LIMIT);
+    loaderOptions.setCodePointLimit(codePointLimit);
     builder.loaderOptions(loaderOptions);
 
-    return builder
+    YAMLFactory retval = ObjectUtils.notNull(builder.build());
+    JsonFactoryFactory.configureJsonFactory(retval);
+    return retval;
+  }
+
+  @NonNull
+  public static YAMLFactory
+      newGeneratorFactoryInstance(@NonNull IMutableConfiguration<SerializationFeature<?>> config) {
+    YAMLFactoryBuilder builder = YAMLFactory.builder();
+    YAMLFactory retval = ObjectUtils.notNull(builder
         .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
         .enable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
         .enable(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS)
         .disable(YAMLGenerator.Feature.SPLIT_LINES)
-        .build();
+        .build());
+    JsonFactoryFactory.configureJsonFactory(retval);
+    return retval;
   }
-
-  public static YAMLFactory instance() {
-    return SINGLETON;
-  }
-
 }

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/YamlFactoryFactory.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/YamlFactoryFactory.java
@@ -27,9 +27,14 @@
 package gov.nist.secauto.metaschema.binding.io.yaml;
 
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 
+import org.yaml.snakeyaml.LoaderOptions;
+
 public final class YamlFactoryFactory {
+  public static final int CODEPOINT_LIMIT = 2 * 1024 * 1024 * 1024; // 2 GB
+
   private static final YAMLFactory SINGLETON = newYamlFactoryInstance();
 
   private YamlFactoryFactory() {
@@ -37,8 +42,15 @@ public final class YamlFactoryFactory {
   }
 
   public static YAMLFactory newYamlFactoryInstance() {
+    YAMLFactoryBuilder builder = YAMLFactory.builder();
+    LoaderOptions loaderOptions = builder.loaderOptions();
+    if (loaderOptions == null) {
+      loaderOptions = new LoaderOptions();
+    }
+    loaderOptions.setCodePointLimit(CODEPOINT_LIMIT);
+    builder.loaderOptions(loaderOptions);
 
-    return YAMLFactory.builder()
+    return builder
         .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
         .enable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
         .enable(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS)

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/YamlOperations.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/YamlOperations.java
@@ -49,7 +49,9 @@ public final class YamlOperations {
   private static final Yaml YAML_PARSER;
 
   static {
-    Constructor constructor = new Constructor(new LoaderOptions());
+    LoaderOptions loaderOptions = new LoaderOptions();
+//    loaderOptions.setCodePointLimit(YamlFactoryFactory.CODEPOINT_LIMIT);
+    Constructor constructor = new Constructor(loaderOptions);
     DumperOptions dumperOptions = new DumperOptions();
     Representer representer = new Representer(dumperOptions);
     YAML_PARSER = new Yaml(constructor, representer, dumperOptions, new Resolver() {

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/YamlOperations.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/yaml/YamlOperations.java
@@ -50,7 +50,7 @@ public final class YamlOperations {
 
   static {
     LoaderOptions loaderOptions = new LoaderOptions();
-//    loaderOptions.setCodePointLimit(YamlFactoryFactory.CODEPOINT_LIMIT);
+    // loaderOptions.setCodePointLimit(YamlFactoryFactory.CODEPOINT_LIMIT);
     Constructor constructor = new Constructor(loaderOptions);
     DumperOptions dumperOptions = new DumperOptions();
     Representer representer = new Representer(dumperOptions);

--- a/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/AbstractMetaschemaMojo.java
+++ b/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/AbstractMetaschemaMojo.java
@@ -238,6 +238,11 @@ public abstract class AbstractMetaschemaMojo
     return skip;
   }
 
+  /**
+   * Get the name of the file that is used to detect staleness.
+   * 
+   * @return the name
+   */
   protected abstract String getStaleFileName();
 
   /**

--- a/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/GenerateSchemaMojo.java
+++ b/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/GenerateSchemaMojo.java
@@ -131,8 +131,8 @@ public class GenerateSchemaMojo
   }
 
   protected void generate(@NonNull Set<IMetaschema> metaschemaCollection) throws MojoExecutionException {
-    IMutableConfiguration<SchemaGenerationFeature> schemaGenerationConfig
-        = new DefaultConfiguration<>(SchemaGenerationFeature.class);
+    IMutableConfiguration<SchemaGenerationFeature<?>> schemaGenerationConfig
+        = new DefaultConfiguration<>();
 
     if (isInlineDefinitions()) {
       schemaGenerationConfig.enableFeature(SchemaGenerationFeature.INLINE_DEFINITIONS);
@@ -178,7 +178,7 @@ public class GenerateSchemaMojo
 
   private static void generateSchemas(
       @NonNull IMetaschema metaschema,
-      @NonNull IConfiguration<SchemaGenerationFeature> schemaGenerationConfig,
+      @NonNull IConfiguration<SchemaGenerationFeature<?>> schemaGenerationConfig,
       @NonNull Path outputDirectory,
       @NonNull Set<SchemaFormat> schemaFormats) throws MojoExecutionException {
 
@@ -207,7 +207,7 @@ public class GenerateSchemaMojo
 
   private static void generateSchema(
       @NonNull IMetaschema metaschema,
-      @NonNull IConfiguration<SchemaGenerationFeature> schemaGenerationConfig,
+      @NonNull IConfiguration<SchemaGenerationFeature<?>> schemaGenerationConfig,
       @NonNull Path schemaPath,
       @NonNull ISchemaGenerator generator) throws IOException {
     try (@SuppressWarnings("resource") Writer writer = ObjectUtils.notNull(Files.newBufferedWriter(

--- a/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/GenerateSourcesMojo.java
+++ b/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/GenerateSourcesMojo.java
@@ -96,6 +96,14 @@ public class GenerateSourcesMojo
     return retval;
   }
 
+  /**
+   * Generate the Java source files for the provided Metaschemas.
+   * 
+   * @param metaschemaCollection
+   *          the collection of Metaschemas to generate sources for
+   * @throws MojoExecutionException
+   *           if an error occurred while generating sources
+   */
   protected void generate(@NonNull Set<IMetaschema> metaschemaCollection) throws MojoExecutionException {
     DefaultBindingConfiguration bindingConfiguration = new DefaultBindingConfiguration();
     for (File config : getConfigs()) {

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/configuration/AbstractConfigurationFeature.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/configuration/AbstractConfigurationFeature.java
@@ -24,24 +24,38 @@
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
 
-package gov.nist.secauto.metaschema.model.common.metapath;
-
-import gov.nist.secauto.metaschema.model.common.configuration.AbstractConfigurationFeature;
+package gov.nist.secauto.metaschema.model.common.configuration;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public final class MetapathEvaluationFeature<V>
-    extends AbstractConfigurationFeature<V> {
-  /**
-   * If enabled, evaluate {@link Predicate} nodes, otherwise skip evaluating them.
-   */
+public abstract class AbstractConfigurationFeature<V> implements IConfigurationFeature<V> {
   @NonNull
-  public static final MetapathEvaluationFeature<Boolean> METAPATH_EVALUATE_PREDICATES
-      = new MetapathEvaluationFeature<>(Boolean.class, true);
+  private final Class<V> valueClass;
+  @NonNull
+  private final V defaultValue;
 
-  private MetapathEvaluationFeature(
+  /**
+   * Construct a new feature with a default value.
+   * 
+   * @param valueClass
+   *          the class of the feature's value
+   * @param defaultValue
+   *          the value's default
+   */
+  protected AbstractConfigurationFeature(
       @NonNull Class<V> valueClass,
       @NonNull V defaultValue) {
-    super(valueClass, defaultValue);
+    this.valueClass = valueClass;
+    this.defaultValue = defaultValue;
+  }
+
+  @Override
+  public V getDefault() {
+    return defaultValue;
+  }
+
+  @Override
+  public Class<V> getValueClass() {
+    return valueClass;
   }
 }

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/configuration/IConfiguration.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/configuration/IConfiguration.java
@@ -26,7 +26,7 @@
 
 package gov.nist.secauto.metaschema.model.common.configuration;
 
-import java.util.Set;
+import java.util.Map;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -38,7 +38,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  *          the type of the feature set
  */
 @SuppressWarnings({ "PMD.DoNotUseThreads", "PMD.ReplaceVectorWithList" })
-public interface IConfiguration<T extends Enum<T> & IConfigurationFeature> {
+public interface IConfiguration<T extends IConfigurationFeature<?>> {
   /**
    * Determines if a specific serialization/deserialization feature is enabled.
    *
@@ -47,12 +47,14 @@ public interface IConfiguration<T extends Enum<T> & IConfigurationFeature> {
    * @return {@code true} if the feature is enabled, or {@code false} otherwise
    */
   boolean isFeatureEnabled(@NonNull T feature);
+  
+  <V> V get(@NonNull T feature);
 
   /**
-   * Get the set of enabled features.
+   * Get the mapping of feature to feature value.
    *
-   * @return the set of enabled features.
+   * @return the mapping.
    */
   @NonNull
-  Set<T> getFeatureSet();
+  Map<T, Object> getFeatureValues();
 }

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/configuration/IConfigurationFeature.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/configuration/IConfigurationFeature.java
@@ -26,18 +26,31 @@
 
 package gov.nist.secauto.metaschema.model.common.configuration;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 /**
  * The common interface that all configuration features must implement.
  * <p>
  * This approach is inspired by the configuration implementation in the
  * <a href="https://github.com/FasterXML/jackson-databind">Jackson databind library</a>.
+ * 
+ * @param <V>
+ *          the value type of the feature
  */
-public interface IConfigurationFeature {
+public interface IConfigurationFeature<V> {
   /**
-   * Determine if the given feature is enabled in the default configuration.
+   * Get the default value of the configuration feature.
    *
-   * @return {@code true} if the feature is enabled in the default configuration, or {@code false}
-   *         otherwise
+   * @return the default value
    */
-  boolean isEnabledByDefault();
+  @NonNull
+  V getDefault();
+
+  /**
+   * Get the class of the feature's value.
+   * 
+   * @return the value's class
+   */
+  @NonNull
+  Class<V> getValueClass();
 }

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/configuration/IMutableConfiguration.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/configuration/IMutableConfiguration.java
@@ -29,7 +29,8 @@ package gov.nist.secauto.metaschema.model.common.configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 @SuppressWarnings({ "PMD.DoNotUseThreads", "PMD.ReplaceVectorWithList" })
-public interface IMutableConfiguration<T extends Enum<T> & IConfigurationFeature> extends IConfiguration<T> {
+public interface IMutableConfiguration<T extends IConfigurationFeature<?>>
+    extends IConfiguration<T> {
   /**
    * Turn on the provided feature.
    *
@@ -38,7 +39,9 @@ public interface IMutableConfiguration<T extends Enum<T> & IConfigurationFeature
    * @return the updated configuration
    */
   @NonNull
-  IMutableConfiguration<T> enableFeature(@NonNull T feature);
+  default IMutableConfiguration<T> enableFeature(@NonNull T feature) {
+    return set(feature, true);
+  }
 
   /**
    * Turn off the provided feature.
@@ -48,7 +51,9 @@ public interface IMutableConfiguration<T extends Enum<T> & IConfigurationFeature
    * @return the updated configuration
    */
   @NonNull
-  IMutableConfiguration<T> disableFeature(@NonNull T feature);
+  default IMutableConfiguration<T> disableFeature(@NonNull T feature) {
+    return set(feature, false);
+  }
 
   /**
    * Replace this configuration with the {@code other} configuration.
@@ -59,4 +64,7 @@ public interface IMutableConfiguration<T extends Enum<T> & IConfigurationFeature
    */
   @NonNull
   IMutableConfiguration<T> applyConfiguration(@NonNull IConfiguration<T> other);
+
+  @NonNull
+  IMutableConfiguration<T> set(@NonNull T feature, @NonNull Object value);
 }

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/DynamicContext.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/DynamicContext.java
@@ -63,7 +63,7 @@ public class DynamicContext { // NOPMD - intentional data class
   private final Map<CallingContext, ISequence<?>> functionResultCache;
   private CachingLoader documentLoader;
   @NonNull
-  private final IMutableConfiguration<MetapathEvaluationFeature> configuration;
+  private final IMutableConfiguration<MetapathEvaluationFeature<?>> configuration;
   @NonNull
   private final Map<String, ISequence<?>> letVariableMap;
 
@@ -77,7 +77,7 @@ public class DynamicContext { // NOPMD - intentional data class
     this.currentDateTime = ZonedDateTime.now(clock);
     this.availableDocuments = new HashMap<>();
     this.functionResultCache = new HashMap<>();
-    this.configuration = new DefaultConfiguration<>(MetapathEvaluationFeature.class);
+    this.configuration = new DefaultConfiguration<>();
     this.configuration.enableFeature(MetapathEvaluationFeature.METAPATH_EVALUATE_PREDICATES);
     this.letVariableMap = new ConcurrentHashMap<>();
   }
@@ -122,7 +122,7 @@ public class DynamicContext { // NOPMD - intentional data class
   }
 
   @NonNull
-  public IConfiguration<MetapathEvaluationFeature> getConfiguration() {
+  public IConfiguration<MetapathEvaluationFeature<?>> getConfiguration() {
     return configuration;
   }
 

--- a/metaschema-model/src/test/java/gov/nist/secauto/metaschema/model/CommonmarkConformanceTest.java
+++ b/metaschema-model/src/test/java/gov/nist/secauto/metaschema/model/CommonmarkConformanceTest.java
@@ -137,7 +137,7 @@ class CommonmarkConformanceTest {
     URL url = MetaschemaLoader.class.getResource(SCHEMA_CLASSPATH);
     // System.out.println(url.toString());
     SchemaFactory schemafactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-    try (InputStream is = MetaschemaLoader.class.getResourceAsStream(SCHEMA_CLASSPATH)) {
+    try (InputStream is = ObjectUtils.requireNonNull(MetaschemaLoader.class.getResourceAsStream(SCHEMA_CLASSPATH))) {
       StreamSource source = new StreamSource(is, url.toURI().toString());
 
       schemafactory.setResourceResolver(new Resolver());

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/AbstractGenerationState.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/AbstractGenerationState.java
@@ -63,7 +63,7 @@ public abstract class AbstractGenerationState<WRITER, DATATYPE_MANAGER extends I
   public AbstractGenerationState(
       @NonNull IMetaschema metaschema,
       @NonNull WRITER writer,
-      @NonNull IConfiguration<SchemaGenerationFeature> configuration,
+      @NonNull IConfiguration<SchemaGenerationFeature<?>> configuration,
       @NonNull DATATYPE_MANAGER datatypeManager) {
     this.metaschema = metaschema;
     this.writer = writer;

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/AbstractSchemaGenerator.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/AbstractSchemaGenerator.java
@@ -86,7 +86,7 @@ public abstract class AbstractSchemaGenerator<T extends AutoCloseable, D extends
   protected abstract S newGenerationState(
       @NonNull IMetaschema metaschema,
       @NonNull T schemaWriter,
-      @NonNull IConfiguration<SchemaGenerationFeature> configuration);
+      @NonNull IConfiguration<SchemaGenerationFeature<?>> configuration);
 
   /**
    * Called to generate the actual schema content.
@@ -100,7 +100,7 @@ public abstract class AbstractSchemaGenerator<T extends AutoCloseable, D extends
   public void generateFromMetaschema(
       IMetaschema metaschema,
       Writer out,
-      IConfiguration<SchemaGenerationFeature> configuration) {
+      IConfiguration<SchemaGenerationFeature<?>> configuration) {
     // IInlineStrategy inlineStrategy = IInlineStrategy.newInlineStrategy(configuration);
     try {
       // avoid automatically closing streams not owned by the generator

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/IInlineStrategy.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/IInlineStrategy.java
@@ -56,7 +56,7 @@ public interface IInlineStrategy {
   IInlineStrategy CHOICE_NOT_INLINE = new ChoiceNotInlineStrategy();
 
   @NonNull
-  static IInlineStrategy newInlineStrategy(@NonNull IConfiguration<SchemaGenerationFeature> configuration) {
+  static IInlineStrategy newInlineStrategy(@NonNull IConfiguration<SchemaGenerationFeature<?>> configuration) {
     IInlineStrategy retval;
     if (configuration.isFeatureEnabled(SchemaGenerationFeature.INLINE_DEFINITIONS)) {
       if (configuration.isFeatureEnabled(SchemaGenerationFeature.INLINE_CHOICE_DEFINITIONS)) {

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/ISchemaGenerator.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/ISchemaGenerator.java
@@ -59,13 +59,13 @@ public interface ISchemaGenerator {
   void generateFromMetaschema(
       @NonNull IMetaschema metaschema,
       @NonNull Writer writer,
-      @NonNull IConfiguration<SchemaGenerationFeature> configuration);
+      @NonNull IConfiguration<SchemaGenerationFeature<?>> configuration);
 
   static void generateSchema(
       @NonNull IMetaschema metaschema,
       @NonNull Path destination,
       @NonNull SchemaFormat asFormat,
-      @NonNull IConfiguration<SchemaGenerationFeature> configuration)
+      @NonNull IConfiguration<SchemaGenerationFeature<?>> configuration)
       throws IOException {
     ISchemaGenerator schemaGenerator = asFormat.getSchemaGenerator();
 
@@ -85,7 +85,7 @@ public interface ISchemaGenerator {
       @NonNull IMetaschema metaschema,
       @NonNull OutputStream os,
       @NonNull SchemaFormat asFormat,
-      @NonNull IConfiguration<SchemaGenerationFeature> configuration)
+      @NonNull IConfiguration<SchemaGenerationFeature<?>> configuration)
       throws IOException {
     ISchemaGenerator schemaGenerator = asFormat.getSchemaGenerator();
 

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/SchemaGenerationFeature.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/SchemaGenerationFeature.java
@@ -26,32 +26,40 @@
 
 package gov.nist.secauto.metaschema.schemagen;
 
-import gov.nist.secauto.metaschema.model.common.configuration.IConfigurationFeature;
+import gov.nist.secauto.metaschema.model.common.configuration.AbstractConfigurationFeature;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Configuration options for schema generation.
+ * 
+ * @param <V>
+ *          the feature value type
  */
-public enum SchemaGenerationFeature implements IConfigurationFeature {
+public final class SchemaGenerationFeature<V>
+    extends AbstractConfigurationFeature<V> {
+
   /**
    * If enabled, definitions that are defined inline will be generated as inline types. If disabled,
    * definitions will always be generated as global types.
    */
-  INLINE_DEFINITIONS(false),
+  @NonNull
+  public static final SchemaGenerationFeature<Boolean> INLINE_DEFINITIONS
+      = new SchemaGenerationFeature<>(Boolean.class, false);
+
   /**
    * If enabled, child definitions of a choice that are defined inline will be generated as inline
    * types. If disabled, child definitions of a choice will always be generated as global types. This
    * option will only be used if {@link #INLINE_DEFINITIONS} is also enabled.
    */
-  INLINE_CHOICE_DEFINITIONS(false);
+  @NonNull
+  public static final SchemaGenerationFeature<Boolean> INLINE_CHOICE_DEFINITIONS
+      = new SchemaGenerationFeature<>(Boolean.class, false);
 
-  private final boolean enabledByDefault;
-
-  SchemaGenerationFeature(boolean enabled) {
-    this.enabledByDefault = enabled;
+  private SchemaGenerationFeature(
+      @NonNull Class<V> valueClass,
+      @NonNull V defaultValue) {
+    super(valueClass, defaultValue);
   }
 
-  @Override
-  public boolean isEnabledByDefault() {
-    return enabledByDefault;
-  }
 }

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/json/JsonGenerationState.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/json/JsonGenerationState.java
@@ -63,15 +63,19 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class JsonGenerationState
     extends AbstractGenerationState<JsonGenerator, JsonDatatypeManager> {
 
+  @NonNull
   private final Set<IDefineableJsonSchema> definitionSchemas = new LinkedHashSet<>();
+  @NonNull
   private final Map<IDefinition, IJsonSchema> definitionToSchemaMap = new ConcurrentHashMap<>();
+  @NonNull
   private final Map<IValuedDefinition, IJsonSchema> definitionValueToDataTypeSchemaMap = new ConcurrentHashMap<>();
+  @NonNull
   private final Map<IDataTypeAdapter<?>, IJsonSchema> dataTypeToSchemaMap = new ConcurrentHashMap<>();
 
   public JsonGenerationState(
       @NonNull IMetaschema metaschema,
       @NonNull JsonGenerator writer,
-      @NonNull IConfiguration<SchemaGenerationFeature> configuration) {
+      @NonNull IConfiguration<SchemaGenerationFeature<?>> configuration) {
     super(metaschema, writer, configuration, new JsonDatatypeManager());
   }
 

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/json/JsonSchemaGenerator.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/json/JsonSchemaGenerator.java
@@ -86,7 +86,7 @@ public class JsonSchemaGenerator
   protected JsonGenerationState newGenerationState(
       IMetaschema metaschema,
       JsonGenerator schemaWriter,
-      IConfiguration<SchemaGenerationFeature> configuration) {
+      IConfiguration<SchemaGenerationFeature<?>> configuration) {
     return new JsonGenerationState(metaschema, schemaWriter, configuration);
   }
 

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/xml/XmlGenerationState.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/xml/XmlGenerationState.java
@@ -82,7 +82,7 @@ public class XmlGenerationState
   public XmlGenerationState(
       @NonNull IMetaschema metaschema,
       @NonNull AutoCloser<XMLStreamWriter2, SchemaGenerationException> writer,
-      @NonNull IConfiguration<SchemaGenerationFeature> configuration) {
+      @NonNull IConfiguration<SchemaGenerationFeature<?>> configuration) {
     super(metaschema, writer, configuration, new XmlDatatypeManager());
     this.defaultNS = ObjectUtils.notNull(metaschema.getXmlNamespace().toASCIIString());
   }

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/xml/XmlSchemaGenerator.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/xml/XmlSchemaGenerator.java
@@ -133,7 +133,7 @@ public class XmlSchemaGenerator
   protected XmlGenerationState newGenerationState(
       IMetaschema metaschema,
       AutoCloser<XMLStreamWriter2, SchemaGenerationException> schemaWriter,
-      IConfiguration<SchemaGenerationFeature> configuration) {
+      IConfiguration<SchemaGenerationFeature<?>> configuration) {
     return new XmlGenerationState(metaschema, schemaWriter, configuration);
   }
 
@@ -141,7 +141,7 @@ public class XmlSchemaGenerator
   public void generateFromMetaschema(
       @NonNull IMetaschema metaschema,
       @NonNull Writer out,
-      @NonNull IConfiguration<SchemaGenerationFeature> configuration) {
+      @NonNull IConfiguration<SchemaGenerationFeature<?>> configuration) {
     try (StringWriter stringWriter = new StringWriter()) {
       super.generateFromMetaschema(metaschema, stringWriter, configuration);
       stringWriter.flush();

--- a/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/AbstractSchemaGeneratorTestSuite.java
+++ b/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/AbstractSchemaGeneratorTestSuite.java
@@ -71,7 +71,7 @@ public abstract class AbstractSchemaGeneratorTestSuite
   @NonNull
   protected static final ISchemaGenerator JSON_SCHEMA_GENERATOR = new JsonSchemaGenerator();
   @NonNull
-  protected static final IConfiguration<SchemaGenerationFeature> SCHEMA_GENERATION_CONFIG;
+  protected static final IConfiguration<SchemaGenerationFeature<?>> SCHEMA_GENERATION_CONFIG;
   @NonNull
   protected static final BiFunction<IMetaschema, Writer, Void> XML_SCHEMA_PROVIDER;
   @NonNull
@@ -87,8 +87,8 @@ public abstract class AbstractSchemaGeneratorTestSuite
       = "../metaschema-model/metaschema/test-suite/schema-generation/unit-tests.xml";
 
   static {
-    IMutableConfiguration<SchemaGenerationFeature> features = new DefaultConfiguration<>(SchemaGenerationFeature.class)
-        .disableFeature(SchemaGenerationFeature.INLINE_DEFINITIONS);
+    IMutableConfiguration<SchemaGenerationFeature<?>> features = new DefaultConfiguration<>();
+    features.disableFeature(SchemaGenerationFeature.INLINE_DEFINITIONS);
     SCHEMA_GENERATION_CONFIG = features;
 
     BiFunction<IMetaschema, Writer, Void> xmlProvider = (metaschema, writer) -> {

--- a/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/JsonSuiteTest.java
+++ b/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/JsonSuiteTest.java
@@ -135,8 +135,9 @@ class JsonSuiteTest
     IMetaschema metaschema = loader.load(new URL(
         "https://raw.githubusercontent.com/usnistgov/OSCAL/develop/src/metaschema/oscal_complete_metaschema.xml"));
     ISchemaGenerator schemaGenerator = new JsonSchemaGenerator();
-    IMutableConfiguration<SchemaGenerationFeature> features = new DefaultConfiguration<>(SchemaGenerationFeature.class)
-        .disableFeature(SchemaGenerationFeature.INLINE_DEFINITIONS);
+    IMutableConfiguration<SchemaGenerationFeature<?>> features
+        = new DefaultConfiguration<>();
+    features.disableFeature(SchemaGenerationFeature.INLINE_DEFINITIONS);
     try (Writer writer = Files.newBufferedWriter(
         Path.of("oscal-complete_schema.json"),
         StandardCharsets.UTF_8,
@@ -153,8 +154,8 @@ class JsonSuiteTest
     IMetaschema metaschema = loader.load(new URL(
         "https://raw.githubusercontent.com/usnistgov/metaschema/71233f4eb6854e820c7949144e86afa4d7981b22/test-suite/metaschema-xspec/json-schema-gen/json-value-testing-mini-metaschema.xml"));
     ISchemaGenerator schemaGenerator = new JsonSchemaGenerator();
-    IMutableConfiguration<SchemaGenerationFeature> features = new DefaultConfiguration<>(SchemaGenerationFeature.class)
-        .disableFeature(SchemaGenerationFeature.INLINE_DEFINITIONS);
+    IMutableConfiguration<SchemaGenerationFeature<?>> features = new DefaultConfiguration<>();
+    features.disableFeature(SchemaGenerationFeature.INLINE_DEFINITIONS);
     try (Writer writer = Files.newBufferedWriter(
         Path.of("json-value-testing-mini_schema.json"),
         StandardCharsets.UTF_8,

--- a/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/XmlSuiteTest.java
+++ b/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/XmlSuiteTest.java
@@ -172,8 +172,8 @@ class XmlSuiteTest
         // "https://raw.githubusercontent.com/usnistgov/OSCAL/develop/src/metaschema/oscal_complete_metaschema.xml"));
         "https://raw.githubusercontent.com/usnistgov/OSCAL/develop/src/metaschema/oscal_complete_metaschema.xml"));
     ISchemaGenerator schemaGenerator = new XmlSchemaGenerator();
-    IMutableConfiguration<SchemaGenerationFeature> features = new DefaultConfiguration<>(SchemaGenerationFeature.class)
-        .disableFeature(SchemaGenerationFeature.INLINE_DEFINITIONS);
+    IMutableConfiguration<SchemaGenerationFeature<?>> features = new DefaultConfiguration<>();
+    features.disableFeature(SchemaGenerationFeature.INLINE_DEFINITIONS);
     try (Writer writer = Files.newBufferedWriter(
         Path.of("oscal-complete_schema.xsd"),
         StandardCharsets.UTF_8,


### PR DESCRIPTION
# Committer Notes

SnakeYaml  has a 3MB codepoint limit for parsing YAML documents. Many OSCAL documents exceed this limit. Need to set a reasonable larger default.

This PR sets the default to 2GB. It also exposes this setting as a deserializer [configuration option](https://github.com/usnistgov/metaschema-java/blob/4f1ff1afc6d96065192c973a88df21c65686ff3e/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/io/DeserializationFeature.java#L59).

To do this, the configuration API had to change to allow non-boolean values. This may cause minor breakage for users of the configuration API.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
