### PR TITLE
CLI Metaschema-based content validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,3 @@ velocity.log*
 node_modules/
 package.json
 package-lock.json
-
-# testing artifacts
-/metaschema-schema-generator/schema.out.xsd
-/metaschema-schema-generator/test-schemagen
-/metaschema-schema-generator/oscal-complete_schema.xsd
-/metaschema-schema-generator/oscal-complete_schema.json
-

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractCommandExecutor.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractCommandExecutor.java
@@ -24,53 +24,44 @@
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
 
-package gov.nist.secauto.metaschema.cli.processor;
+package gov.nist.secauto.metaschema.cli.processor.command;
 
-import gov.nist.secauto.metaschema.cli.processor.command.Command;
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
+import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 
-import java.util.List;
-import java.util.ServiceLoader;
-import java.util.ServiceLoader.Provider;
-import java.util.stream.Collectors;
+import org.apache.commons.cli.CommandLine;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import nl.talsmasoftware.lazy4j.Lazy;
 
-public final class CommandService {
-  private static final Lazy<CommandService> INSTANCE = Lazy.lazy(() -> new CommandService());
+public abstract class AbstractCommandExecutor implements ICommandExecutor {
   @NonNull
-  private final ServiceLoader<Command> loader;
+  private final CallingContext callingContext;
+  @NonNull
+  private final CommandLine commandLine;
 
-  /**
-   * Get the singleton instance of the function service.
-   *
-   * @return the service instance
-   */
-  public static CommandService getInstance() {
-    return INSTANCE.get();
+  public AbstractCommandExecutor(
+      @NonNull CallingContext callingContext,
+      @NonNull CommandLine commandLine) {
+    this.callingContext = callingContext;
+    this.commandLine = commandLine;
   }
 
-  public CommandService() {
-    ServiceLoader<Command> loader = ServiceLoader.load(Command.class);
-    assert loader != null;
-    this.loader = loader;
+  @NonNull
+  protected CallingContext getCallingContext() {
+    return callingContext;
   }
 
-  /**
-   * Get the function service loader instance.
-   *
-   * @return the service loader instance.
-   */
   @NonNull
-  private ServiceLoader<Command> getLoader() {
-    return loader;
+  protected CommandLine getCommandLine() {
+    return commandLine;
   }
 
-  @SuppressWarnings("null")
+  @Override
+  public abstract ExitStatus execute();
+
   @NonNull
-  public List<Command> getCommands() {
-    return getLoader().stream()
-        .map(Provider<Command>::get)
-        .collect(Collectors.toUnmodifiableList());
+  protected ICommand getCommand() {
+    return ObjectUtils.requireNonNull(getCallingContext().getTargetCommand());
   }
 }

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractParentCommand.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractParentCommand.java
@@ -40,9 +40,9 @@ import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public abstract class AbstractParentCommand implements Command {
+public abstract class AbstractParentCommand implements ICommand {
   @NonNull
-  private final Map<String, Command> commandToSubcommandHandlerMap;
+  private final Map<String, ICommand> commandToSubcommandHandlerMap;
   private final boolean subCommandRequired;
 
   @SuppressWarnings("null")
@@ -51,19 +51,19 @@ public abstract class AbstractParentCommand implements Command {
     this.subCommandRequired = subCommandRequired;
   }
 
-  protected void addCommandHandler(Command handler) {
+  protected void addCommandHandler(ICommand handler) {
     String commandName = handler.getName();
     this.commandToSubcommandHandlerMap.put(commandName, handler);
   }
 
   @Override
-  public Command getSubCommandByName(String name) {
+  public ICommand getSubCommandByName(String name) {
     return commandToSubcommandHandlerMap.get(name);
   }
 
   @SuppressWarnings("null")
   @Override
-  public Collection<Command> getSubCommands() {
+  public Collection<ICommand> getSubCommands() {
     return Collections.unmodifiableCollection(commandToSubcommandHandlerMap.values());
   }
 
@@ -73,7 +73,14 @@ public abstract class AbstractParentCommand implements Command {
   }
 
   @Override
-  public ExitStatus executeCommand(CallingContext callingContext, CommandLine cmdLine) {
+  public ICommandExecutor newExecutor(CallingContext callingContext, CommandLine cmdLine) {
+    return ICommandExecutor.using(callingContext, cmdLine, this::executeCommand);
+  }
+
+  @NonNull
+  protected ExitStatus executeCommand(
+      @NonNull CallingContext callingContext,
+      @NonNull CommandLine commandLine) {
     callingContext.showHelp();
     ExitStatus status;
     if (isSubCommandRequired()) {

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractTerminalCommand.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractTerminalCommand.java
@@ -33,11 +33,11 @@ import java.util.Collections;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public abstract class AbstractTerminalCommand implements Command {
+public abstract class AbstractTerminalCommand implements ICommand {
 
   @SuppressWarnings("null")
   @Override
-  public Collection<Command> getSubCommands() {
+  public Collection<ICommand> getSubCommands() {
     return Collections.emptyList();
   }
 

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ICommand.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ICommand.java
@@ -27,7 +27,6 @@
 package gov.nist.secauto.metaschema.cli.processor.command;
 
 import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
-import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
 import gov.nist.secauto.metaschema.cli.processor.InvalidArgumentException;
 import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
 
@@ -39,7 +38,7 @@ import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public interface Command {
+public interface ICommand {
   @NonNull
   String getName();
 
@@ -63,6 +62,17 @@ public interface Command {
     return CollectionUtil.emptyList();
   }
 
+  @NonNull
+  Collection<ICommand> getSubCommands();
+
+  boolean isSubCommandRequired();
+
+  @SuppressWarnings("unused")
+  default ICommand getSubCommandByName(@NonNull String name) {
+    // no sub commands by default
+    return null;
+  }
+
   @SuppressWarnings("unused")
   default void validateOptions(
       @NonNull CallingContext callingContext,
@@ -71,16 +81,5 @@ public interface Command {
   }
 
   @NonNull
-  ExitStatus executeCommand(@NonNull CallingContext callingContext, @NonNull CommandLine cmdLine);
-
-  @NonNull
-  Collection<Command> getSubCommands();
-
-  boolean isSubCommandRequired();
-
-  @SuppressWarnings("unused")
-  default Command getSubCommandByName(@NonNull String name) {
-    // no sub commands by default
-    return null;
-  }
+  ICommandExecutor newExecutor(@NonNull CallingContext callingContext, @NonNull CommandLine cmdLine);
 }

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ICommandExecutor.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ICommandExecutor.java
@@ -24,73 +24,38 @@
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
 
-package gov.nist.secauto.metaschema.model.common.metapath.item;
+package gov.nist.secauto.metaschema.cli.processor.command;
 
-import gov.nist.secauto.metaschema.model.common.IFieldDefinition;
-import gov.nist.secauto.metaschema.model.common.IFieldInstance;
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
+
+import org.apache.commons.cli.CommandLine;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-/**
- * A {@link INodeItem} supported by a {@link IFieldInstance}.
- *
- * @param <F>
- *          the flag node item type
- * @param <P>
- *          the parent node item type
- */
-abstract class AbstractFieldInstanceNodeItem<F extends IFlagNodeItem, P extends IAssemblyNodeItem, L extends AbstractNodeContext.Flags<
-    F>>
-    extends AbstractNodeContext<F, L>
-    implements IFieldNodeItem {
+public interface ICommandExecutor {
   @NonNull
-  private final IFieldInstance instance;
-  private final int position;
-  @NonNull
-  private final P parent;
+  ExitStatus execute();
 
-  public AbstractFieldInstanceNodeItem(
-      @NonNull IFieldInstance instance,
-      @NonNull P parent,
-      int position,
-      @NonNull INodeItemFactory factory) {
-    super(factory);
-    this.instance = instance;
-    this.parent = parent;
-    if (position < 1) {
-      throw new IllegalArgumentException(
-          String.format(
-              "The position must be positive, but found '%d'",
-              position));
-    }
-    this.position = position;
+  @NonNull
+  static ICommandExecutor using(
+      @NonNull CallingContext callingContext,
+      @NonNull CommandLine commandLine,
+      @NonNull ExecutionFunction function) {
+    return new ICommandExecutor() {
+      @Override
+      public ExitStatus execute() {
+        return function.execute(callingContext, commandLine);
+      }
+
+    };
   }
 
-  @Override
-  @NonNull
-  public P getParentContentNodeItem() {
-    return getParentNodeItem();
-  }
-
-  @Override
-  @NonNull
-  public P getParentNodeItem() {
-    return parent;
-  }
-
-  @Override
-  public IFieldDefinition getDefinition() {
-    return getInstance().getDefinition();
-  }
-
-  @Override
-  @NonNull
-  public IFieldInstance getInstance() {
-    return instance;
-  }
-
-  @Override
-  public int getPosition() {
-    return position;
+  @FunctionalInterface
+  public interface ExecutionFunction {
+    @NonNull
+    ExitStatus execute(
+        @NonNull CallingContext callingContext,
+        @NonNull CommandLine commandLine);
   }
 }

--- a/metaschema-cli/pom.xml
+++ b/metaschema-cli/pom.xml
@@ -35,6 +35,10 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>metaschema-java-binding</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>metaschema-java-codegen</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>com.google.auto.service</groupId>

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/CLI.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/CLI.java
@@ -27,10 +27,11 @@
 package gov.nist.secauto.metaschema.cli;
 
 import gov.nist.secauto.metaschema.cli.commands.GenerateSchemaCommand;
-import gov.nist.secauto.metaschema.cli.commands.ValidateCommand;
+import gov.nist.secauto.metaschema.cli.commands.ValidateContentWithMetaschemaCommand;
+import gov.nist.secauto.metaschema.cli.commands.ValidateMetaschemaCommand;
 import gov.nist.secauto.metaschema.cli.processor.CLIProcessor;
-import gov.nist.secauto.metaschema.cli.processor.CommandService;
 import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
+import gov.nist.secauto.metaschema.cli.processor.command.CommandService;
 import gov.nist.secauto.metaschema.model.MetaschemaVersion;
 import gov.nist.secauto.metaschema.model.common.util.IVersionInfo;
 import gov.nist.secauto.metaschema.model.common.util.MetaschemaJavaVersion;
@@ -55,8 +56,9 @@ public final class CLI {
             new MetaschemaJavaVersion(),
             new MetaschemaVersion()));
     CLIProcessor processor = new CLIProcessor("metaschema-cli", versions);
-    processor.addCommandHandler(new ValidateCommand());
+    processor.addCommandHandler(new ValidateMetaschemaCommand());
     processor.addCommandHandler(new GenerateSchemaCommand());
+    processor.addCommandHandler(new ValidateContentWithMetaschemaCommand());
 
     CommandService.getInstance().getCommands().stream().forEach(command -> {
       assert command != null;

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
@@ -194,6 +194,10 @@ public abstract class AbstractConvertSubcommand
       IBindingContext bindingContext = getBindingContext();
       try {
         IBoundLoader loader = bindingContext.newBoundLoader();
+        if (LOGGER.isInfoEnabled()) {
+          LOGGER.info("Converting '{}'.", source);
+        }
+
         if (destination == null) {
           loader.convert(source, ObjectUtils.notNull(System.out), toFormat, getLoadedClass());
         } else {

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
@@ -246,6 +246,10 @@ public abstract class AbstractValidateContentCommand
         }
       }
 
+      if (LOGGER.isInfoEnabled()) {
+        LOGGER.info("Validating '{}' as {}.", source, asFormat.name());
+      }
+
       IValidationResult validationResult;
       try {
         validationResult = bindingContext.validate(source, asFormat, this);

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
@@ -35,6 +35,7 @@ import gov.nist.secauto.metaschema.cli.processor.OptionUtils;
 import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;
 import gov.nist.secauto.metaschema.cli.processor.command.DefaultExtraArgument;
 import gov.nist.secauto.metaschema.cli.processor.command.ExtraArgument;
+import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
 import gov.nist.secauto.metaschema.model.MetaschemaLoader;
 import gov.nist.secauto.metaschema.model.common.IMetaschema;
 import gov.nist.secauto.metaschema.model.common.MetaschemaException;
@@ -155,7 +156,17 @@ public class GenerateSchemaCommand
   }
 
   @Override
-  public ExitStatus executeCommand(CallingContext callingContext, CommandLine cmdLine) {
+  public ICommandExecutor newExecutor(CallingContext callingContext, CommandLine cmdLine) {
+    return ICommandExecutor.using(callingContext, cmdLine, this::executeCommand);
+  }
+
+  @SuppressWarnings({
+      "PMD.OnlyOneReturn", // readability
+      "unused"
+  })
+  protected ExitStatus executeCommand(
+      @NonNull CallingContext callingContext,
+      @NonNull CommandLine cmdLine) {
     List<String> extraArgs = cmdLine.getArgList();
 
     Path destination = null;
@@ -219,5 +230,4 @@ public class GenerateSchemaCommand
     }
     return ExitCode.OK.exit();
   }
-
 }

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
@@ -214,7 +214,13 @@ public class GenerateSchemaCommand
     Path input = Paths.get(extraArgs.get(0));
     assert input != null;
     try {
-      IMetaschema metaschema = new MetaschemaLoader().load(input);
+      MetaschemaLoader loader = new MetaschemaLoader();
+      loader.allowEntityResolution();
+      IMetaschema metaschema = loader.load(input);
+
+      if (LOGGER.isInfoEnabled()) {
+        LOGGER.info("Generating {} schema for '{}'.", asFormat.name(), input);
+      }
       if (destination == null) {
         @SuppressWarnings({ "resource", "PMD.CloseResource" }) // not owned
         OutputStream os = ObjectUtils.notNull(System.out);

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/MetaschemaCommandSupport.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/MetaschemaCommandSupport.java
@@ -24,73 +24,26 @@
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
 
-package gov.nist.secauto.metaschema.model.common.metapath.item;
+package gov.nist.secauto.metaschema.cli.commands;
 
-import gov.nist.secauto.metaschema.model.common.IFieldDefinition;
-import gov.nist.secauto.metaschema.model.common.IFieldInstance;
+import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
+
+import org.apache.commons.cli.Option;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-/**
- * A {@link INodeItem} supported by a {@link IFieldInstance}.
- *
- * @param <F>
- *          the flag node item type
- * @param <P>
- *          the parent node item type
- */
-abstract class AbstractFieldInstanceNodeItem<F extends IFlagNodeItem, P extends IAssemblyNodeItem, L extends AbstractNodeContext.Flags<
-    F>>
-    extends AbstractNodeContext<F, L>
-    implements IFieldNodeItem {
+public class MetaschemaCommandSupport {
   @NonNull
-  private final IFieldInstance instance;
-  private final int position;
-  @NonNull
-  private final P parent;
+  public static final Option METASCHEMA_OPTION = ObjectUtils.notNull(
+      Option.builder("m")
+          .hasArg()
+          .argName("FILE")
+          .required()
+          .desc("metaschema resource")
+          .build());
 
-  public AbstractFieldInstanceNodeItem(
-      @NonNull IFieldInstance instance,
-      @NonNull P parent,
-      int position,
-      @NonNull INodeItemFactory factory) {
-    super(factory);
-    this.instance = instance;
-    this.parent = parent;
-    if (position < 1) {
-      throw new IllegalArgumentException(
-          String.format(
-              "The position must be positive, but found '%d'",
-              position));
-    }
-    this.position = position;
+  public MetaschemaCommandSupport() {
+    // TODO Auto-generated constructor stub
   }
 
-  @Override
-  @NonNull
-  public P getParentContentNodeItem() {
-    return getParentNodeItem();
-  }
-
-  @Override
-  @NonNull
-  public P getParentNodeItem() {
-    return parent;
-  }
-
-  @Override
-  public IFieldDefinition getDefinition() {
-    return getInstance().getDefinition();
-  }
-
-  @Override
-  @NonNull
-  public IFieldInstance getInstance() {
-    return instance;
-  }
-
-  @Override
-  public int getPosition() {
-    return position;
-  }
 }

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateContentWithMetaschemaCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateContentWithMetaschemaCommand.java
@@ -138,6 +138,7 @@ public class ValidateContentWithMetaschemaCommand
         assert metaschemaPath != null;
 
         MetaschemaLoader loader = new MetaschemaLoader(constraintSets);
+        loader.allowEntityResolution();
         metaschema = loader.load(metaschemaPath);
       }
       assert metaschema != null;

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateContentWithMetaschemaCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateContentWithMetaschemaCommand.java
@@ -1,0 +1,182 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.commands;
+
+import gov.nist.secauto.metaschema.binding.IBindingContext;
+import gov.nist.secauto.metaschema.binding.io.xml.XmlUtil;
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.InvalidArgumentException;
+import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
+import gov.nist.secauto.metaschema.codegen.binding.DynamicBindingContext;
+import gov.nist.secauto.metaschema.model.MetaschemaLoader;
+import gov.nist.secauto.metaschema.model.common.IMetaschema;
+import gov.nist.secauto.metaschema.model.common.MetaschemaException;
+import gov.nist.secauto.metaschema.model.common.configuration.DefaultConfiguration;
+import gov.nist.secauto.metaschema.model.common.configuration.IMutableConfiguration;
+import gov.nist.secauto.metaschema.model.common.constraint.IConstraintSet;
+import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
+import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
+import gov.nist.secauto.metaschema.model.common.validation.JsonSchemaContentValidator;
+import gov.nist.secauto.metaschema.schemagen.ISchemaGenerator;
+import gov.nist.secauto.metaschema.schemagen.ISchemaGenerator.SchemaFormat;
+import gov.nist.secauto.metaschema.schemagen.SchemaGenerationFeature;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import javax.xml.transform.Source;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class ValidateContentWithMetaschemaCommand
+    extends AbstractValidateContentCommand {
+  @NonNull
+  private static final String COMMAND = "validate-content";
+
+  @Override
+  public String getName() {
+    return COMMAND;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Verify that the provided resource is well-formed and valid to the provided Metaschema-based model.";
+  }
+
+  @Override
+  public Collection<? extends Option> gatherOptions() {
+    Collection<? extends Option> orig = super.gatherOptions();
+
+    List<Option> retval = new ArrayList<>(orig.size() + 1);
+    retval.addAll(orig);
+    retval.add(MetaschemaCommandSupport.METASCHEMA_OPTION);
+
+    return CollectionUtil.unmodifiableCollection(retval);
+  }
+
+  @Override
+  public void validateOptions(CallingContext callingContext, CommandLine cmdLine) throws InvalidArgumentException {
+    super.validateOptions(callingContext, cmdLine);
+
+    String metaschemaName = cmdLine.getOptionValue(MetaschemaCommandSupport.METASCHEMA_OPTION);
+    Path metaschema = Paths.get(metaschemaName);
+    if (!Files.exists(metaschema)) {
+      throw new InvalidArgumentException("The provided metaschema '" + metaschema + "' does not exist.");
+    }
+    if (!Files.isReadable(metaschema)) {
+      throw new InvalidArgumentException("The provided metaschema '" + metaschema + "' is not readable.");
+    }
+  }
+
+  @Override
+  public ICommandExecutor newExecutor(CallingContext callingContext, CommandLine commandLine) {
+    return new OscalCommandExecutor(callingContext, commandLine);
+  }
+
+  private class OscalCommandExecutor
+      extends AbstractValidationCommandExecutor {
+
+    private Path tempDir;
+    private IMetaschema metaschema;
+
+    private OscalCommandExecutor(
+        @NonNull CallingContext callingContext,
+        @NonNull CommandLine commandLine) {
+      super(callingContext, commandLine);
+    }
+
+    private Path getTempDir() throws IOException {
+      if (tempDir == null) {
+        tempDir = Files.createTempDirectory("validation-");
+        tempDir.toFile().deleteOnExit();
+      }
+      return tempDir;
+    }
+
+    @NonNull
+    private IMetaschema getMetaschema(@NonNull Set<IConstraintSet> constraintSets)
+        throws MetaschemaException, IOException {
+      if (metaschema == null) {
+        String metaschemaName = getCommandLine().getOptionValue(MetaschemaCommandSupport.METASCHEMA_OPTION);
+        Path metaschemaPath = Paths.get(metaschemaName);
+        assert metaschemaPath != null;
+
+        MetaschemaLoader loader = new MetaschemaLoader(constraintSets);
+        metaschema = loader.load(metaschemaPath);
+      }
+      assert metaschema != null;
+      return metaschema;
+    }
+
+    @NonNull
+    private IMetaschema getMetaschema() {
+      // should be initialized already
+      return ObjectUtils.requireNonNull(metaschema);
+    }
+
+    @Override
+    protected IBindingContext getBindingContext(@NonNull Set<IConstraintSet> constraintSets)
+        throws MetaschemaException, IOException {
+
+      return DynamicBindingContext.forMetaschema(getMetaschema(constraintSets), getTempDir());
+    }
+
+    @Override
+    public List<Source> getXmlSchemas() throws IOException {
+      Path schemaFile = Files.createTempFile(getTempDir(), "schema-", ".json");
+      assert schemaFile != null;
+      IMutableConfiguration<SchemaGenerationFeature<?>> configuration = new DefaultConfiguration<>();
+      ISchemaGenerator.generateSchema(getMetaschema(), schemaFile, SchemaFormat.XML, configuration);
+      return ObjectUtils.requireNonNull(List.of(
+          XmlUtil.getStreamSource(schemaFile.toUri().toURL())));
+    }
+
+    @Override
+    public JSONObject getJsonSchema() throws IOException {
+      Path schemaFile = Files.createTempFile(getTempDir(), "schema-", ".json");
+      assert schemaFile != null;
+      IMutableConfiguration<SchemaGenerationFeature<?>> configuration = new DefaultConfiguration<>();
+      ISchemaGenerator.generateSchema(getMetaschema(), schemaFile, SchemaFormat.JSON, configuration);
+      try (BufferedReader reader = ObjectUtils.notNull(Files.newBufferedReader(schemaFile, StandardCharsets.UTF_8))) {
+        return JsonSchemaContentValidator.toJsonObject(reader);
+      }
+    }
+  }
+
+}

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateMetaschemaCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateMetaschemaCommand.java
@@ -35,6 +35,7 @@ import gov.nist.secauto.metaschema.cli.processor.InvalidArgumentException;
 import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;
 import gov.nist.secauto.metaschema.cli.processor.command.DefaultExtraArgument;
 import gov.nist.secauto.metaschema.cli.processor.command.ExtraArgument;
+import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
 import gov.nist.secauto.metaschema.cli.util.LoggingValidationHandler;
 import gov.nist.secauto.metaschema.model.MetaschemaLoader;
 import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
@@ -58,9 +59,9 @@ import javax.xml.transform.Source;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public class ValidateCommand
+public class ValidateMetaschemaCommand
     extends AbstractTerminalCommand {
-  private static final Logger LOGGER = LogManager.getLogger(ValidateCommand.class);
+  private static final Logger LOGGER = LogManager.getLogger(ValidateMetaschemaCommand.class);
   @NonNull
   private static final String COMMAND = "validate";
   @NonNull
@@ -110,9 +111,14 @@ public class ValidateCommand
     }
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn") // readability
   @Override
-  public ExitStatus executeCommand(CallingContext callingContext, CommandLine cmdLine) {
+  public ICommandExecutor newExecutor(CallingContext callingContext, CommandLine cmdLine) {
+    return ICommandExecutor.using(callingContext, cmdLine, this::executeCommand);
+  }
+
+  @SuppressWarnings("PMD.OnlyOneReturn") // readability
+  @NonNull
+  protected ExitStatus executeCommand(CallingContext callingContext, CommandLine cmdLine) {
     List<String> extraArgs = cmdLine.getArgList();
     Path target = Paths.get(extraArgs.get(0));
     assert target != null;

--- a/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/IBindingContext.java
+++ b/metaschema-java-binding/src/main/java/gov/nist/secauto/metaschema/binding/IBindingContext.java
@@ -341,7 +341,7 @@ public interface IBindingContext extends IMetaschemaLoaderStrategy {
 
   interface IValidationSchemaProvider {
     @NonNull
-    JSONObject getJsonSchema();
+    JSONObject getJsonSchema() throws IOException;
 
     @NonNull
     List<Source> getXmlSchemas() throws IOException;

--- a/metaschema-java-codegen/src/main/java/gov/nist/secauto/metaschema/codegen/MetaschemaCompilerHelper.java
+++ b/metaschema-java-codegen/src/main/java/gov/nist/secauto/metaschema/codegen/MetaschemaCompilerHelper.java
@@ -65,6 +65,10 @@ public final class MetaschemaCompilerHelper {
   private static final Logger LOGGER = LogManager.getLogger(MetaschemaCompilerHelper.class);
   private static final MetaschemaLoader LOADER = new MetaschemaLoader();
 
+  static {
+    LOADER.allowEntityResolution();
+  }
+
   private MetaschemaCompilerHelper() {
     // disable construction
   }

--- a/metaschema-java-codegen/src/test/java/gov/nist/secauto/metaschema/codegen/test/TestBasicMetaschema.java
+++ b/metaschema-java-codegen/src/test/java/gov/nist/secauto/metaschema/codegen/test/TestBasicMetaschema.java
@@ -150,13 +150,13 @@ class TestBasicMetaschema {
         }
 
         LOGGER.info("Write XML:");
-        write(Format.XML, ObjectUtils.notNull(Paths.get("out.xml")), root);
+        write(Format.XML, ObjectUtils.notNull(Paths.get("target/out.xml")), root);
 
         LOGGER.info("Write JSON:");
-        write(Format.XML, ObjectUtils.notNull(Paths.get("out.json")), root);
+        write(Format.XML, ObjectUtils.notNull(Paths.get("target/out.json")), root);
       }
 
-      Object root = read(Format.XML, ObjectUtils.notNull(Paths.get("out.xml")), rootClass);
+      Object root = read(Format.XML, ObjectUtils.notNull(Paths.get("target/out.xml")), rootClass);
       if (assertions != null) {
         assertAll("Deserialize XML (roundtrip)", () -> assertions.accept(root));
       }

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/AbstractModelNodeContext.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/metapath/item/AbstractModelNodeContext.java
@@ -34,10 +34,8 @@ import java.util.Map;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public abstract class AbstractModelNodeContext<
-    F extends IFlagNodeItem,
-    M extends IModelNodeItem,
-    L extends AbstractModelNodeContext.Model<F, M>>
+public abstract class AbstractModelNodeContext<F extends IFlagNodeItem, M extends IModelNodeItem, L extends AbstractModelNodeContext.Model<
+    F, M>>
     extends AbstractNodeContext<F, L> {
 
   /**
@@ -46,8 +44,7 @@ public abstract class AbstractModelNodeContext<
    * @param factory
    *          the factory to use to instantiate new node items
    */
-  protected AbstractModelNodeContext(@NonNull
-  INodeItemFactory factory) {
+  protected AbstractModelNodeContext(@NonNull INodeItemFactory factory) {
     super(factory);
   }
 
@@ -84,10 +81,8 @@ public abstract class AbstractModelNodeContext<
      *          a mapping of model item name to a list of model items
      */
     protected Model(
-        @NonNull
-        Map<String, F> flags,
-        @NonNull
-        Map<String, List<M>> modelItems) {
+        @NonNull Map<String, F> flags,
+        @NonNull Map<String, List<M>> modelItems) {
       super(flags);
       this.modelItems = modelItems;
     }
@@ -100,8 +95,7 @@ public abstract class AbstractModelNodeContext<
      * @return a lisy of matching model items or {@code null} if no match was found
      */
     @NonNull
-    public List<M> getModelItemsByName(@NonNull
-    String name) {
+    public List<M> getModelItemsByName(@NonNull String name) {
       List<M> result = modelItems.get(
           name);
       return result == null ? CollectionUtil.emptyList() : result;

--- a/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/validation/JsonSchemaContentValidator.java
+++ b/metaschema-model-common/src/main/java/gov/nist/secauto/metaschema/model/common/validation/JsonSchemaContentValidator.java
@@ -39,6 +39,7 @@ import org.xml.sax.InputSource;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
@@ -56,6 +57,11 @@ public class JsonSchemaContentValidator implements IContentValidator {
   @NonNull
   public static JSONObject toJsonObject(@NonNull InputStream schemaInputStream) {
     return new JSONObject(new JSONTokener(schemaInputStream));
+  }
+
+  @NonNull
+  public static JSONObject toJsonObject(@NonNull Reader reader) {
+    return new JSONObject(new JSONTokener(reader));
   }
 
   public JsonSchemaContentValidator(@NonNull InputStream schemaInputStream) {

--- a/metaschema-model/src/test/java/gov/nist/secauto/metaschema/model/ExamplesTest.java
+++ b/metaschema-model/src/test/java/gov/nist/secauto/metaschema/model/ExamplesTest.java
@@ -43,6 +43,7 @@ class ExamplesTest {
   @Test
   void testLoadMetaschema() throws MetaschemaException, IOException {
     MetaschemaLoader loader = new MetaschemaLoader();
+    loader.allowEntityResolution();
 
     URI metaschemaUri = ObjectUtils.notNull(URI.create(
         "https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.0/src/metaschema/oscal_complete_metaschema.xml"));
@@ -53,6 +54,7 @@ class ExamplesTest {
   @Test
   void testExamineAssemblyDefinitionByName() throws MetaschemaException, IOException {
     MetaschemaLoader loader = new MetaschemaLoader();
+    loader.allowEntityResolution();
     URI metaschemaUri = ObjectUtils.notNull(URI.create(
         "https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.0/src/metaschema/oscal_complete_metaschema.xml"));
     IMetaschema metaschema = loader.load(metaschemaUri);

--- a/metaschema-model/src/test/java/gov/nist/secauto/metaschema/model/util/UsedDefinitionModelWalkerTest.java
+++ b/metaschema-model/src/test/java/gov/nist/secauto/metaschema/model/util/UsedDefinitionModelWalkerTest.java
@@ -50,6 +50,7 @@ class UsedDefinitionModelWalkerTest {
   @Test
   void test() throws MetaschemaException, IOException {
     MetaschemaLoader loader = new MetaschemaLoader();
+    loader.allowEntityResolution();
 
     IMetaschema metaschema = loader.load(new URL(
         "https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.0/src/metaschema/oscal_complete_metaschema.xml"));

--- a/metaschema-model/src/test/resources/content/custom-entity-metaschema.xml
+++ b/metaschema-model/src/test/resources/content/custom-entity-metaschema.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE METASCHEMA [
+   <!ENTITY allowed-values-entity SYSTEM "entity-file.ent">
+]>
+<METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
+	<schema-name>Test Metaschema with an external entity</schema-name>
+	<schema-version>1.0.4</schema-version>
+	<short-name>external-entity-test</short-name>
+	<namespace>http://csrc.nist.gov/ns/test/metaschema/entity</namespace>
+	<json-base-uri>http://csrc.nist.gov/ns/test/metaschema/entity</json-base-uri>
+	<define-assembly name="root">
+		<root-name>root</root-name>
+		<model>
+			<define-field name="name" as-type="token" max-occurs="unbounded">
+				<group-as name="names" in-json="ARRAY" />
+			</define-field>
+		</model>
+		<constraint>
+			<allowed-values target="name">
+                &allowed-values-entity;
+			</allowed-values>
+		</constraint>
+	</define-assembly>
+</METASCHEMA>

--- a/metaschema-model/src/test/resources/content/entity-file.ent
+++ b/metaschema-model/src/test/resources/content/entity-file.ent
@@ -1,0 +1,1 @@
+<enum xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" value="value1">The first value type.</enum>

--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/ISchemaGenerator.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/ISchemaGenerator.java
@@ -95,6 +95,9 @@ public interface ISchemaGenerator {
     // we don't want to close os, since we do not own it
   }
 
+  /**
+   * Identifies the supported schema generation formats.
+   */
   enum SchemaFormat {
     /**
      * a JSON Schema.

--- a/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/AbstractSchemaGeneratorTestSuite.java
+++ b/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/AbstractSchemaGeneratorTestSuite.java
@@ -29,6 +29,7 @@ package gov.nist.secauto.metaschema.schemagen;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import gov.nist.secauto.metaschema.binding.io.Format;
+import gov.nist.secauto.metaschema.codegen.binding.DynamicBindingContext;
 import gov.nist.secauto.metaschema.model.MetaschemaLoader;
 import gov.nist.secauto.metaschema.model.common.IMetaschema;
 import gov.nist.secauto.metaschema.model.common.MetaschemaException;
@@ -39,7 +40,6 @@ import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 import gov.nist.secauto.metaschema.model.common.validation.JsonSchemaContentValidator;
 import gov.nist.secauto.metaschema.model.common.validation.XmlSchemaContentValidator;
 import gov.nist.secauto.metaschema.model.testing.AbstractTestSuite;
-import gov.nist.secauto.metaschema.model.testing.DynamicBindingContext;
 import gov.nist.secauto.metaschema.schemagen.json.JsonSchemaGenerator;
 import gov.nist.secauto.metaschema.schemagen.xml.XmlSchemaGenerator;
 
@@ -60,9 +60,10 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public abstract class AbstractSchemaGeneratorTestSuite
     extends AbstractTestSuite {
@@ -202,7 +203,9 @@ public abstract class AbstractSchemaGeneratorTestSuite
       throw new IllegalStateException();
     }
 
-    DynamicBindingContext context = produceDynamicBindingContext(metaschema, generationDir);
+    DynamicBindingContext context = DynamicBindingContext.forMetaschema(
+        metaschema,
+        generationDir);
     for (ContentCase contentCase : contentCases) {
       Path contentPath = collectionPath.resolve(contentCase.getName());
 

--- a/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/AbstractSchemaGeneratorTestSuite.java
+++ b/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/AbstractSchemaGeneratorTestSuite.java
@@ -182,6 +182,7 @@ public abstract class AbstractSchemaGeneratorTestSuite
     Path collectionPath = testSuite.resolve(collectionName);
 
     MetaschemaLoader loader = new MetaschemaLoader();
+    loader.allowEntityResolution();
     Path metaschemaPath = collectionPath.resolve(metaschemaName);
     IMetaschema metaschema = loader.load(metaschemaPath);
 

--- a/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/JsonSuiteTest.java
+++ b/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/JsonSuiteTest.java
@@ -139,7 +139,7 @@ class JsonSuiteTest
         = new DefaultConfiguration<>();
     features.disableFeature(SchemaGenerationFeature.INLINE_DEFINITIONS);
     try (Writer writer = Files.newBufferedWriter(
-        Path.of("oscal-complete_schema.json"),
+        Path.of("target/oscal-complete_schema.json"),
         StandardCharsets.UTF_8,
         getWriteOpenOptions())) {
       assert writer != null;
@@ -157,7 +157,7 @@ class JsonSuiteTest
     IMutableConfiguration<SchemaGenerationFeature<?>> features = new DefaultConfiguration<>();
     features.disableFeature(SchemaGenerationFeature.INLINE_DEFINITIONS);
     try (Writer writer = Files.newBufferedWriter(
-        Path.of("json-value-testing-mini_schema.json"),
+        Path.of("target/json-value-testing-mini_schema.json"),
         StandardCharsets.UTF_8,
         getWriteOpenOptions())) {
       assert writer != null;

--- a/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/JsonSuiteTest.java
+++ b/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/JsonSuiteTest.java
@@ -132,6 +132,8 @@ class JsonSuiteTest
   @Test
   void testOSCALComplete() throws IOException, MetaschemaException { // NOPMD - delegated to doTest
     MetaschemaLoader loader = new MetaschemaLoader();
+    loader.allowEntityResolution();
+
     IMetaschema metaschema = loader.load(new URL(
         "https://raw.githubusercontent.com/usnistgov/OSCAL/develop/src/metaschema/oscal_complete_metaschema.xml"));
     ISchemaGenerator schemaGenerator = new JsonSchemaGenerator();
@@ -151,6 +153,7 @@ class JsonSuiteTest
   @Test
   void testTestMetaschema() throws IOException, MetaschemaException { // NOPMD - delegated to doTest
     MetaschemaLoader loader = new MetaschemaLoader();
+    loader.allowEntityResolution();
     IMetaschema metaschema = loader.load(new URL(
         "https://raw.githubusercontent.com/usnistgov/metaschema/71233f4eb6854e820c7949144e86afa4d7981b22/test-suite/metaschema-xspec/json-schema-gen/json-value-testing-mini-metaschema.xml"));
     ISchemaGenerator schemaGenerator = new JsonSchemaGenerator();

--- a/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/XmlSuiteTest.java
+++ b/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/XmlSuiteTest.java
@@ -168,6 +168,8 @@ class XmlSuiteTest
   @Test
   void testOSCALComplete() throws IOException, MetaschemaException { // NOPMD - delegated to doTest
     MetaschemaLoader loader = new MetaschemaLoader();
+    loader.allowEntityResolution();
+
     IMetaschema metaschema = loader.load(new URL(
         // "https://raw.githubusercontent.com/usnistgov/OSCAL/develop/src/metaschema/oscal_complete_metaschema.xml"));
         "https://raw.githubusercontent.com/usnistgov/OSCAL/develop/src/metaschema/oscal_complete_metaschema.xml"));

--- a/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/XmlSuiteTest.java
+++ b/metaschema-schema-generator/src/test/java/gov/nist/secauto/metaschema/schemagen/XmlSuiteTest.java
@@ -175,7 +175,7 @@ class XmlSuiteTest
     IMutableConfiguration<SchemaGenerationFeature<?>> features = new DefaultConfiguration<>();
     features.disableFeature(SchemaGenerationFeature.INLINE_DEFINITIONS);
     try (Writer writer = Files.newBufferedWriter(
-        Path.of("oscal-complete_schema.xsd"),
+        Path.of("target/oscal-complete_schema.xsd"),
         StandardCharsets.UTF_8,
         getWriteOpenOptions())) {
       assert writer != null;

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/AbstractTestSuite.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/AbstractTestSuite.java
@@ -87,6 +87,10 @@ public abstract class AbstractTestSuite {
 
   private static final boolean DELETE_RESULTS_ON_EXIT = false;
 
+  static {
+    LOADER.allowEntityResolution();
+  }
+
   @NonNull
   protected abstract Format getRequiredContentFormat();
 


### PR DESCRIPTION
# Committer Notes

Added support for Metaschema-based content validation using an arbitrary Metaschema in the CLI as the `validate-content`  command. This command requires a `-m` argument pointing to the Metaschema to use. It automatically compiles the binding classes and generates the appropriate XML or JSON schema,

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
