### PR TITLE
Handle RuntimeExceptions that occurr during command execution

### DIFF
--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/ExitCode.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/ExitCode.java
@@ -40,7 +40,7 @@ public enum ExitCode {
   /**
    * The argument information for a command is invalid.
    */
-  INPUT_ERROR(2),
+  IO_ERROR(2),
   /**
    * A command was requested by name that doesn't exist.
    */

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/ExitCode.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/ExitCode.java
@@ -30,11 +30,30 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public enum ExitCode {
   OK(0),
+  /**
+   * The command executed properly, but the operation failed.
+   */
   FAIL(1),
+  /**
+   * The argument information for a command is invalid.
+   */
   INPUT_ERROR(2),
+  /**
+   * A command was requested by name that doesn't exist.
+   */
   INVALID_COMMAND(3),
+  /**
+   * The target argument was not found or invalid.
+   */
   INVALID_TARGET(4),
-  PROCESSING_ERROR(5);
+  /**
+   * Handled errors that occur during command execution.
+   */
+  PROCESSING_ERROR(5),
+  /**
+   * Unhandled errors that occur during command execution.
+   */
+  RUNTIME_ERROR(6);
 
   private final int statusCode;
 

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/ExitCode.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/ExitCode.java
@@ -29,6 +29,9 @@ package gov.nist.secauto.metaschema.cli.processor;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public enum ExitCode {
+  /**
+   * The command executed without issue.
+   */
   OK(0),
   /**
    * The command executed properly, but the operation failed.

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/ExitCode.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/ExitCode.java
@@ -38,11 +38,11 @@ public enum ExitCode {
    */
   FAIL(1),
   /**
-   * The argument information for a command is invalid.
+   * An error occurred while reading or writing.
    */
   IO_ERROR(2),
   /**
-   * A command was requested by name that doesn't exist.
+   * A command was requested by name that doesn't exist or required arguments are missing.
    */
   INVALID_COMMAND(3),
   /**
@@ -56,7 +56,11 @@ public enum ExitCode {
   /**
    * Unhandled errors that occur during command execution.
    */
-  RUNTIME_ERROR(6);
+  RUNTIME_ERROR(6),
+  /**
+   * The provided argument information for a command fails to match argument use requirements.
+   */
+  INVALID_ARGUMENTS(7);
 
   private final int statusCode;
 

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
@@ -164,7 +164,7 @@ public abstract class AbstractConvertSubcommand
       if (destination != null) {
         if (Files.exists(destination)) {
           if (!cmdLine.hasOption(OVERWRITE_OPTION)) {
-            return ExitCode.IO_ERROR.exitMessage(
+            return ExitCode.INVALID_ARGUMENTS.exitMessage(
                 String.format("The provided destination '%s' already exists and the '%s' option was not provided.",
                     destination,
                     OptionUtils.toArgument(OVERWRITE_OPTION)));

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
@@ -164,13 +164,13 @@ public abstract class AbstractConvertSubcommand
       if (destination != null) {
         if (Files.exists(destination)) {
           if (!cmdLine.hasOption(OVERWRITE_OPTION)) {
-            return ExitCode.INPUT_ERROR.exitMessage(
+            return ExitCode.IO_ERROR.exitMessage(
                 String.format("The provided destination '%s' already exists and the '%s' option was not provided.",
                     destination,
                     OptionUtils.toArgument(OVERWRITE_OPTION)));
           }
           if (!Files.isWritable(destination)) {
-            return ExitCode.INPUT_ERROR.exitMessage(
+            return ExitCode.IO_ERROR.exitMessage(
                 "The provided destination '" + destination + "' is not writable.");
           }
         } else {

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
@@ -164,13 +164,13 @@ public abstract class AbstractConvertSubcommand
       if (destination != null) {
         if (Files.exists(destination)) {
           if (!cmdLine.hasOption(OVERWRITE_OPTION)) {
-            return ExitCode.FAIL.exitMessage(
+            return ExitCode.INPUT_ERROR.exitMessage(
                 String.format("The provided destination '%s' already exists and the '%s' option was not provided.",
                     destination,
                     OptionUtils.toArgument(OVERWRITE_OPTION)));
           }
           if (!Files.isWritable(destination)) {
-            return ExitCode.FAIL.exitMessage(
+            return ExitCode.INPUT_ERROR.exitMessage(
                 "The provided destination '" + destination + "' is not writable.");
           }
         } else {
@@ -204,7 +204,7 @@ public abstract class AbstractConvertSubcommand
           loader.convert(source, destination, toFormat, getLoadedClass());
         }
       } catch (IOException | IllegalArgumentException ex) {
-        return ExitCode.FAIL.exit().withThrowable(ex); // NOPMD readability
+        return ExitCode.PROCESSING_ERROR.exit().withThrowable(ex); // NOPMD readability
       }
       if (destination != null && LOGGER.isInfoEnabled()) {
         LOGGER.info("Generated {} file: {}", toFormat.toString(), destination);

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
@@ -194,7 +194,7 @@ public abstract class AbstractValidateContentCommand
           try {
             constraintSets.add(constraintLoader.load(constraintPath));
           } catch (IOException | MetaschemaException ex) {
-            return ExitCode.INPUT_ERROR.exitMessage("Unable to load constraint set '" + arg + "'.").withThrowable(ex);
+            return ExitCode.IO_ERROR.exitMessage("Unable to load constraint set '" + arg + "'.").withThrowable(ex);
           }
         }
       } else {
@@ -221,7 +221,7 @@ public abstract class AbstractValidateContentCommand
           String toFormatText = cmdLine.getOptionValue(AS_OPTION);
           asFormat = Format.valueOf(toFormatText.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException ex) {
-          return ExitCode.INPUT_ERROR
+          return ExitCode.IO_ERROR
               .exitMessage("Invalid '--as' argument. The format must be one of: "
                   + Arrays.stream(Format.values())
                       .map(format -> format.name())
@@ -238,7 +238,7 @@ public abstract class AbstractValidateContentCommand
         } catch (IOException ex) {
           return ExitCode.PROCESSING_ERROR.exit().withThrowable(ex);
         } catch (IllegalArgumentException ex) {
-          return ExitCode.INPUT_ERROR.exitMessage(
+          return ExitCode.IO_ERROR.exitMessage(
               "Source file has unrecognizable format. Use '--as' to specify the format. The format must be one of: "
                   + Arrays.stream(Format.values())
                       .map(format -> format.name())

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
@@ -234,7 +234,7 @@ public abstract class AbstractValidateContentCommand
           asFormat = loader.detectFormat(source);
         } catch (FileNotFoundException ex) {
           // this case was already checked for
-          return ExitCode.INPUT_ERROR.exitMessage("The provided source file '" + source + "' does not exist.");
+          return ExitCode.IO_ERROR.exitMessage("The provided source file '" + source + "' does not exist.");
         } catch (IOException ex) {
           return ExitCode.PROCESSING_ERROR.exit().withThrowable(ex);
         } catch (IllegalArgumentException ex) {

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
@@ -194,7 +194,7 @@ public abstract class AbstractValidateContentCommand
           try {
             constraintSets.add(constraintLoader.load(constraintPath));
           } catch (IOException | MetaschemaException ex) {
-            return ExitCode.FAIL.exitMessage("Unable to load constraint set '" + arg + "'.").withThrowable(ex);
+            return ExitCode.INPUT_ERROR.exitMessage("Unable to load constraint set '" + arg + "'.").withThrowable(ex);
           }
         }
       } else {
@@ -204,7 +204,7 @@ public abstract class AbstractValidateContentCommand
       try {
         bindingContext = getBindingContext(constraintSets);
       } catch (IOException | MetaschemaException ex) {
-        return ExitCode.FAIL
+        return ExitCode.PROCESSING_ERROR
             .exitMessage("Unable to get binding context. " + ex.getMessage())
             .withThrowable(ex);
       }
@@ -221,7 +221,7 @@ public abstract class AbstractValidateContentCommand
           String toFormatText = cmdLine.getOptionValue(AS_OPTION);
           asFormat = Format.valueOf(toFormatText.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException ex) {
-          return ExitCode.FAIL
+          return ExitCode.INPUT_ERROR
               .exitMessage("Invalid '--as' argument. The format must be one of: "
                   + Arrays.stream(Format.values())
                       .map(format -> format.name())
@@ -236,9 +236,9 @@ public abstract class AbstractValidateContentCommand
           // this case was already checked for
           return ExitCode.INPUT_ERROR.exitMessage("The provided source file '" + source + "' does not exist.");
         } catch (IOException ex) {
-          return ExitCode.FAIL.exit().withThrowable(ex);
+          return ExitCode.PROCESSING_ERROR.exit().withThrowable(ex);
         } catch (IllegalArgumentException ex) {
-          return ExitCode.FAIL.exitMessage(
+          return ExitCode.INPUT_ERROR.exitMessage(
               "Source file has unrecognizable format. Use '--as' to specify the format. The format must be one of: "
                   + Arrays.stream(Format.values())
                       .map(format -> format.name())

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
@@ -177,7 +177,7 @@ public class GenerateSchemaCommand
     if (destination != null) {
       if (Files.exists(destination)) {
         if (!cmdLine.hasOption(OVERWRITE_OPTION)) {
-          return ExitCode.IO_ERROR.exitMessage( // NOPMD readability
+          return ExitCode.INVALID_ARGUMENTS.exitMessage( // NOPMD readability
               String.format("The provided destination '%s' already exists and the '%s' option was not provided.",
                   destination,
                   OptionUtils.toArgument(OVERWRITE_OPTION)));

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
@@ -177,13 +177,13 @@ public class GenerateSchemaCommand
     if (destination != null) {
       if (Files.exists(destination)) {
         if (!cmdLine.hasOption(OVERWRITE_OPTION)) {
-          return ExitCode.INPUT_ERROR.exitMessage( // NOPMD readability
+          return ExitCode.IO_ERROR.exitMessage( // NOPMD readability
               String.format("The provided destination '%s' already exists and the '%s' option was not provided.",
                   destination,
                   OptionUtils.toArgument(OVERWRITE_OPTION)));
         }
         if (!Files.isWritable(destination)) {
-          return ExitCode.INPUT_ERROR.exitMessage( // NOPMD readability
+          return ExitCode.IO_ERROR.exitMessage( // NOPMD readability
               "The provided destination '" + destination + "' is not writable.");
         }
       } else {

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
@@ -177,13 +177,13 @@ public class GenerateSchemaCommand
     if (destination != null) {
       if (Files.exists(destination)) {
         if (!cmdLine.hasOption(OVERWRITE_OPTION)) {
-          return ExitCode.FAIL.exitMessage( // NOPMD readability
+          return ExitCode.INPUT_ERROR.exitMessage( // NOPMD readability
               String.format("The provided destination '%s' already exists and the '%s' option was not provided.",
                   destination,
                   OptionUtils.toArgument(OVERWRITE_OPTION)));
         }
         if (!Files.isWritable(destination)) {
-          return ExitCode.FAIL.exitMessage( // NOPMD readability
+          return ExitCode.INPUT_ERROR.exitMessage( // NOPMD readability
               "The provided destination '" + destination + "' is not writable.");
         }
       } else {
@@ -229,7 +229,7 @@ public class GenerateSchemaCommand
         ISchemaGenerator.generateSchema(metaschema, destination, asFormat, configuration);
       }
     } catch (IOException | MetaschemaException ex) {
-      return ExitCode.FAIL.exit().withThrowable(ex); // NOPMD readability
+      return ExitCode.PROCESSING_ERROR.exit().withThrowable(ex); // NOPMD readability
     }
     if (destination != null && LOGGER.isInfoEnabled()) {
       LOGGER.info("Generated {} schema file: {}", asFormat.toString(), destination);


### PR DESCRIPTION
# Committer Notes

Cleaned up error codes and added catch for RuntimeExceptions during command execution, which now result in a RUNTIME_ERROR. 

**Note: Some error code results may change as the result of this update.**

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
