### PR TITLE
Fix missing type reference on generated attributes for flags

### DIFF
--- a/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/xml/schematype/AbstractXmlComplexType.java
+++ b/metaschema-schema-generator/src/main/java/gov/nist/secauto/metaschema/schemagen/xml/schematype/AbstractXmlComplexType.java
@@ -93,7 +93,7 @@ public abstract class AbstractXmlComplexType<D extends IFlagContainer>
 
     IXmlType type = state.getTypeForDefinition(definition);
 
-    if (state.isInline(definition)) {
+    if (state.isInline(definition) && type.isGeneratedType(state)) {
       DocumentationGenerator.generateDocumentation(instance, state);
 
       type.generateType(state, true);


### PR DESCRIPTION
# Committer Notes

Fixed a bug caused when the SchemaGenerationFeature.INLINE_DEFINITIONS is enabled causing XML schema type references to not be produced for attributes associated with flags. This change restores the correct behavior by adding a type.isGeneratedType conditional check. Resolves usnistgov/liboscal-java#181.

This issue is difficult to test for, since it involves testing a specialized schema generation configuration. A [new issue](https://github.com/usnistgov/metaschema-java/issues/217) has been created to work on this.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
