### PR TITLE
Fix dependency bounds issue for usnistgov/metaschema#265

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
 		<dependency.woodstox.version>6.5.1</dependency.woodstox.version>
 		<dependency.xmlbeans.version>5.2.0</dependency.xmlbeans.version>
 		<dependency.xmlcalabash.version>1.5.6-120</dependency.xmlcalabash.version>
-		<dependency.xmlresolver.version>5.2.0</dependency.xmlresolver.version>
+		<dependency.xmlresolver.version>5.2.2</dependency.xmlresolver.version>
 		<dependency.xml-apis.version>2.0.2</dependency.xml-apis.version>
 
 		<plugin.antlr4test.version>1.22</plugin.antlr4test.version>


### PR DESCRIPTION
# Committer Notes

Fix dependency bounds issue for usnistgov/metaschema#265

More details with the reason for this PR can be found in the build
mentioned below.

```sh
Error:  Rule 0: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for org.xmlresolver:xmlresolver:5.2.0 paths to dependency are:
+-gov.nist.secauto.metaschema:metaschema-schema-generator:1.0.0-M2-SNAPSHOT
  +-net.sf.saxon:Saxon-HE:12.4
    +-org.xmlresolver:xmlresolver:5.2.0 (managed) <-- org.xmlresolver:xmlresolver:5.2.2
and
+-gov.nist.secauto.metaschema:metaschema-schema-generator:1.0.0-M2-SNAPSHOT
  +-net.sf.saxon:Saxon-HE:12.4
    +-org.xmlresolver:xmlresolver:5.2.0:data (managed) <-- org.xmlresolver:xmlresolver:5.2.2:data
]
```

https://github.com/usnistgov/metaschema-java/actions/runs/7042748869/job/19167401850

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~ N/A
- ~Have you included examples of how to use your new feature(s)?~ N/A
- ~Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.~ N/A
