### PR TITLE
Parameterize existing CLI tests with streaming test vectors

### DIFF
--- a/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
+++ b/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
@@ -32,8 +32,20 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import gov.nist.secauto.metaschema.cli.processor.ExitCode;
 import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
+import gov.nist.secauto.metaschema.cli.CLI;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -41,47 +53,49 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Unit test for simple CLI.
  */
 public class CLITest {
-  void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode) {
-	    status.generateMessage(true);
-	    assertAll(
-	        () -> assertEquals(expectedCode, status.getExitCode(), "exit code mismatch"),
-        () -> assertNull(status.getThrowable(), "expected null Throwable"));
-  }
+	void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode) {
+		status.generateMessage(true);
+		assertAll(() -> assertEquals(expectedCode, status.getExitCode(), "exit code mismatch"),
+				() -> assertNull(status.getThrowable(), "expected null Throwable"));
+	}
 
-  void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode,
-      @NonNull Class<? extends Throwable> thrownClass) {
-    status.generateMessage(true);
-    Throwable thrown = status.getThrowable();
-    assert thrown != null;
-    assertAll(
-        () -> assertEquals(expectedCode, status.getExitCode(), "exit code mismatch"),
-        () -> assertEquals(thrownClass, thrown.getClass(), "expected Throwable mismatch"));
-  }
+	void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode,
+			@NonNull Class<? extends Throwable> thrownClass) {
+		status.generateMessage(true);
+		Throwable thrown = status.getThrowable();
+		assert thrown != null;
+		assertAll(() -> assertEquals(expectedCode, status.getExitCode(), "exit code mismatch"),
+				() -> assertEquals(thrownClass, thrown.getClass(), "expected Throwable mismatch"));
+	}
 
-  @Test
-  void testHelp() {
-    String[] args = {};
-    evaluateResult(CLI.runCli(args), ExitCode.INVALID_COMMAND);
-  }
+	private static Stream<Arguments> providesValues() {
+		ExitCode noExpectedExceptionClass = null;
+		List<Arguments> values = new ArrayList<>();
+		values.add(Arguments.of(new String[] {}, ExitCode.INVALID_COMMAND, noExpectedExceptionClass));
+		values.add(Arguments.of(new String[] { "-h" }, ExitCode.OK, noExpectedExceptionClass));
+		values.add(Arguments.of(new String[] { "generate-schema", "--help" }, ExitCode.INVALID_COMMAND,
+				noExpectedExceptionClass));
+		values.add(Arguments.of(new String[] { "validate", "--help" }, ExitCode.OK, noExpectedExceptionClass));
+		values.add(Arguments.of(new String[] { "validate-content", "--help" }, ExitCode.INVALID_COMMAND,
+				noExpectedExceptionClass));
+		values.add(Arguments.of(
+				new String[] { "validate",
+						"../databind/src/test/resources/metaschema/fields_with_flags/metaschema.xml" },
+				ExitCode.OK, noExpectedExceptionClass));
+		values.add(Arguments.of(new String[] { "generate-schema", "--overwrite", "--as", "JSON",
+				"../databind/src/test/resources/metaschema/fields_with_flags/metaschema.xml",
+				"target/schema-test.json" }, ExitCode.OK, noExpectedExceptionClass));
+		return values.stream();
+	}
 
-  @Test
-  void testHelpArg() {
-    String[] args = { "-h" };
-    evaluateResult(CLI.runCli(args), ExitCode.OK);
-  }
-
-  @Test
-  void testMetaschemaValidate() {
-    String[] args = { "validate",
-        "../databind/src/test/resources/metaschema/fields_with_flags/metaschema.xml" };
-    evaluateResult(CLI.runCli(args), ExitCode.OK);
-  }
-
-  @Test
-  void testMetaschemaGenerateSchema() {
-    String[] args = { "generate-schema", "--overwrite", "--as", "JSON",
-        "../databind/src/test/resources/metaschema/fields_with_flags/metaschema.xml",
-        "target/schema-test.json" };
-    evaluateResult(CLI.runCli(args), ExitCode.OK);
-  }
+	@ParameterizedTest
+	@MethodSource("providesValues")
+	void testAllCommands(@NonNull String[] args, @NonNull ExitCode expectedExitCode,
+			Class<? extends Throwable> expectedThrownClass) {
+		if (expectedThrownClass == null) {
+			evaluateResult(CLI.runCli(args), expectedExitCode);
+		} else {
+			evaluateResult(CLI.runCli(args), expectedExitCode, expectedThrownClass);
+		}
+	}
 }

--- a/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
+++ b/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
@@ -41,6 +41,23 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Unit test for simple CLI.
  */
 public class CLITest {
+  void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode) {
+	    status.generateMessage(true);
+	    assertAll(
+	        () -> assertEquals(expectedCode, status.getExitCode(), "exit code mismatch"),
+        () -> assertNull(status.getThrowable(), "expected null Throwable"));
+  }
+
+  void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode,
+      @NonNull Class<? extends Throwable> thrownClass) {
+    status.generateMessage(true);
+    Throwable thrown = status.getThrowable();
+    assert thrown != null;
+    assertAll(
+        () -> assertEquals(expectedCode, status.getExitCode(), "exit code mismatch"),
+        () -> assertEquals(thrownClass, thrown.getClass(), "expected Throwable mismatch"));
+  }
+
   @Test
   void testHelp() {
     String[] args = {};
@@ -66,22 +83,5 @@ public class CLITest {
         "../databind/src/test/resources/metaschema/fields_with_flags/metaschema.xml",
         "target/schema-test.json" };
     evaluateResult(CLI.runCli(args), ExitCode.OK);
-  }
-
-  void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode) {
-    status.generateMessage(true);
-    assertAll(
-        () -> assertEquals(expectedCode, status.getExitCode(), "exit code mismatch"),
-        () -> assertNull(status.getThrowable(), "expected null Throwable"));
-  }
-
-  void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode,
-      @NonNull Class<? extends Throwable> thrownClass) {
-    status.generateMessage(true);
-    Throwable thrown = status.getThrowable();
-    assert thrown != null;
-    assertAll(
-        () -> assertEquals(expectedCode, status.getExitCode(), "exit code mismatch"),
-        () -> assertEquals(thrownClass, thrown.getClass(), "expected Throwable mismatch"));
   }
 }


### PR DESCRIPTION
# Committer Notes

Use the parameterized method source style of tests so we can easily add similar tests for new `metaschema-cli query ...` functionality coming up in #241 for testing.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- ~Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.~ N/A this is part of the test harness and doesn't have user-facing spec and implementation changes, it only impacts maintainers.
