### PR TITLE
Improve NPE error messages for missing data

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/AbstractMarkupWriter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/AbstractMarkupWriter.java
@@ -126,10 +126,10 @@ public abstract class AbstractMarkupWriter<T, E extends Throwable> // NOPMD not 
   @NonNull
   private final ListOptions options;
 
-  public AbstractMarkupWriter(@NonNull String namespace, @NonNull ListOptions options, T stream) {
+  public AbstractMarkupWriter(@NonNull String namespace, @NonNull ListOptions options, @NonNull T stream) {
     this.namespace = namespace;
     this.options = options;
-    this.stream = ObjectUtils.requireNonNull(stream);
+    this.stream = stream;
   }
 
   @NonNull
@@ -303,7 +303,7 @@ public abstract class AbstractMarkupWriter<T, E extends Throwable> // NOPMD not 
     }
 
     if (!node.getTitle().isBlank()) {
-      String title = ObjectUtils.requireNonNull(node.getTitle().unescape());
+      String title = ObjectUtils.notNull(node.getTitle().unescape());
       attributes.put("title", title);
     }
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/BuildCSTVisitor.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/BuildCSTVisitor.java
@@ -753,8 +753,7 @@ public class BuildCSTVisitor
     // for SimpleForBinding ("," SimpleForBinding)*
     int bindingCount = simpleForClause.getChildCount() / 2;
 
-    @NonNull
-    IExpression retval = ObjectUtils.notNull(ctx.exprsingle().accept(this));
+    @NonNull IExpression retval = ObjectUtils.notNull(ctx.exprsingle().accept(this));
 
     // step through in reverse
     for (int idx = bindingCount - 1; idx >= 0; idx--) {
@@ -783,8 +782,7 @@ public class BuildCSTVisitor
 
   @Override
   protected IExpression handleLet(LetexprContext context) {
-    @NonNull
-    IExpression retval = ObjectUtils.notNull(context.exprsingle().accept(this));
+    @NonNull IExpression retval = ObjectUtils.notNull(context.exprsingle().accept(this));
 
     SimpleletclauseContext letClause = context.simpleletclause();
     List<SimpleletbindingContext> clauses = letClause.simpleletbinding();

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionService.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionService.java
@@ -77,7 +77,7 @@ public final class FunctionService {
         .flatMap(library -> {
           return library.getFunctionsAsStream();
         })
-        .forEachOrdered(function -> functionLibrary.registerFunction(ObjectUtils.requireNonNull(function)));
+        .forEachOrdered(function -> functionLibrary.registerFunction(ObjectUtils.notNull(function)));
 
     synchronized (this) {
       this.library = functionLibrary;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/ModelFactory.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/ModelFactory.java
@@ -131,8 +131,14 @@ public final class ModelFactory {
     Map<String, IAllowedValue> allowedValues // NOPMD - intentional
         = new LinkedHashMap<>(xmlObject.sizeOfEnumArray());
     for (AllowedValueType xmlEnum : xmlObject.getEnumList()) {
+      String value = xmlEnum.getValue();
+      if (value == null) {
+        throw new IllegalStateException(String.format("Null value found in allowed value enumeration: %s",
+            xmlObject.xmlText()));
+      }
+
       IAllowedValue allowedValue = IAllowedValue.of(
-          ObjectUtils.requireNonNull(xmlEnum.getValue()),
+          value,
           MarkupStringConverter.toMarkupString(xmlEnum));
       allowedValues.put(allowedValue.getValue(), allowedValue);
     }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlAssemblyModelContainer.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlAssemblyModelContainer.java
@@ -182,7 +182,19 @@ public class XmlAssemblyModelContainer
     XmlChoiceGroupInstance instance = new XmlChoiceGroupInstance(
         (GroupedChoiceType) obj,
         ObjectUtils.notNull(state.getLeft()));
-    ObjectUtils.notNull(state.getRight()).append(instance);
+    XmlAssemblyModelContainer container = ObjectUtils.notNull(state.getRight());
+
+    String groupAsName = instance.getGroupAsName();
+    if (groupAsName == null) {
+      String location = XmlObjectParser.toLocation(obj);
+      String locationCtx = location == null ? "" : " at location " + location;
+      throw new IllegalArgumentException(
+          String.format("Missing group-as for a choice group within the definition '%s'%s.",
+              instance.getContainingDefinition().getName(),
+              locationCtx));
+    }
+    container.getChoiceGroupInstanceMap().put(groupAsName, instance);
+    container.getModelInstances().add(instance);
   }
 
   public void append(@NonNull IFieldInstanceAbsolute instance) {
@@ -201,11 +213,6 @@ public class XmlAssemblyModelContainer
 
   public void append(@NonNull IChoiceInstance instance) {
     getChoiceInstances().add(instance);
-    getModelInstances().add(instance);
-  }
-
-  public void append(@NonNull IChoiceGroupInstance instance) {
-    getChoiceGroupInstanceMap().put(ObjectUtils.requireNonNull(instance.getGroupAsName()), instance);
     getModelInstances().add(instance);
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlObjectParser.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlObjectParser.java
@@ -107,8 +107,14 @@ public class XmlObjectParser<T> {
     return xpath;
   }
 
+  @SuppressWarnings({ "resource", "null" })
   @Nullable
-  public static String getLocation(@NonNull XmlCursor cursor) {
+  public static String toLocation(@NonNull XmlObject obj) {
+    return toLocation(obj.newCursor());
+  }
+
+  @Nullable
+  public static String toLocation(@NonNull XmlCursor cursor) {
     String retval = null;
     XmlBookmark bookmark = cursor.getBookmark(XmlLineNumber.class);
     if (bookmark != null) {
@@ -150,7 +156,7 @@ public class XmlObjectParser<T> {
     QName qname = cursor.getName();
     Handler<T> retval = getElementNameToHandlerMap().get(qname);
     if (retval == null) {
-      String location = getLocation(cursor);
+      String location = toLocation(cursor);
       if (location == null) {
         location = "";
       } else {

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/DefaultBindingContext.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/DefaultBindingContext.java
@@ -322,8 +322,7 @@ public class DefaultBindingContext implements IBindingContext {
     if (definition == null) {
       throw new IllegalStateException(String.format("Class '%s' is not bound", other.getClass().getName()));
     }
-    @SuppressWarnings("unchecked")
-    CLASS retval = (CLASS) definition.deepCopyItem(other, parentInstance);
+    @SuppressWarnings("unchecked") CLASS retval = (CLASS) definition.deepCopyItem(other, parentInstance);
     return retval;
   }
 }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/DefaultBindingContext.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/DefaultBindingContext.java
@@ -145,10 +145,14 @@ public class DefaultBindingContext implements IBindingContext {
   @Override
   public IBindingMatcher registerBindingMatcher(@NonNull Class<?> clazz) {
     IBoundDefinitionModelComplex definition = getBoundDefinitionForClass(clazz);
+    if (definition == null) {
+      throw new IllegalArgumentException(String.format("Unable to find bound definition for class '%s'.",
+          clazz.getName()));
+    }
 
     try {
       IBoundDefinitionModelAssembly assemblyDefinition = IBoundDefinitionModelAssembly.class.cast(definition);
-      return registerBindingMatcher(ObjectUtils.requireNonNull(assemblyDefinition));
+      return registerBindingMatcher(ObjectUtils.notNull(assemblyDefinition));
     } catch (ClassCastException ex) {
       throw new IllegalArgumentException(
           String.format("The provided class '%s' is not a root assembly.", clazz.getName()), ex);
@@ -265,7 +269,7 @@ public class DefaultBindingContext implements IBindingContext {
             }
           })
           .forEachOrdered(clazz -> {
-            IBoundModule boundModule = registerModule(ObjectUtils.requireNonNull(clazz));
+            IBoundModule boundModule = registerModule(ObjectUtils.notNull(clazz));
             // force the binding matchers to load
             boundModule.getRootAssemblyDefinitions();
           });
@@ -318,7 +322,8 @@ public class DefaultBindingContext implements IBindingContext {
     if (definition == null) {
       throw new IllegalStateException(String.format("Class '%s' is not bound", other.getClass().getName()));
     }
-    @SuppressWarnings("unchecked") CLASS retval = (CLASS) definition.deepCopyItem(other, parentInstance);
+    @SuppressWarnings("unchecked")
+    CLASS retval = (CLASS) definition.deepCopyItem(other, parentInstance);
     return retval;
   }
 }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonReader.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonReader.java
@@ -394,7 +394,14 @@ public class MetaschemaJsonReader
       JsonParser parser = getReader();
       ObjectNode node = parser.readValueAsTree();
 
-      JsonNode descriminatorNode = ObjectUtils.requireNonNull(node.get(instance.getJsonDiscriminatorProperty()));
+      String descriminatorProperty = instance.getJsonDiscriminatorProperty();
+      JsonNode descriminatorNode = node.get(descriminatorProperty);
+      if (descriminatorNode == null) {
+        throw new IllegalArgumentException(String.format(
+            "Unable to find descriminator property '%s' for object at '%s'.",
+            descriminatorProperty,
+            JsonUtil.toString(parser)));
+      }
       String discriminator = ObjectUtils.requireNonNull(descriminatorNode.asText());
 
       IBoundInstanceModelGroupedNamed actualInstance = instance.getGroupedModelInstance(discriminator);
@@ -432,7 +439,8 @@ public class MetaschemaJsonReader
       @Override
       public void accept(IBoundDefinitionModelComplex definition, Object parentItem, IJsonProblemHandler problemHandler)
           throws IOException {
-        @SuppressWarnings("resource") JsonParser parser = getReader();
+        @SuppressWarnings("resource")
+        JsonParser parser = getReader();
         JsonUtil.assertCurrent(parser, JsonToken.FIELD_NAME);
 
         // the field will be the JSON key
@@ -469,7 +477,8 @@ public class MetaschemaJsonReader
           Object parentItem,
           IJsonProblemHandler problemHandler)
           throws IOException {
-        @SuppressWarnings("resource") JsonParser parser = getReader();
+        @SuppressWarnings("resource")
+        JsonParser parser = getReader();
 
         // advance past the start object
         JsonUtil.assertAndAdvance(parser, JsonToken.START_OBJECT);
@@ -593,7 +602,8 @@ public class MetaschemaJsonReader
         if (foundJsonValueKey) {
           retval = delegate.handleUnknownProperty(definition, parentItem, fieldName, reader);
         } else {
-          @SuppressWarnings("resource") JsonParser parser = getReader();
+          @SuppressWarnings("resource")
+          JsonParser parser = getReader();
           // handle JSON value key
           String key = ObjectUtils.notNull(parser.getCurrentName());
           Object keyValue = jsonValueKyeFlag.getJavaTypeAdapter().parse(key);
@@ -693,7 +703,8 @@ public class MetaschemaJsonReader
 
       IBoundInstanceModel instance = getCollectionInfo().getInstance();
 
-      @SuppressWarnings("PMD.UseConcurrentHashMap") Map<String, Object> items = new LinkedHashMap<>();
+      @SuppressWarnings("PMD.UseConcurrentHashMap")
+      Map<String, Object> items = new LinkedHashMap<>();
 
       // A map value is always wrapped in a START_OBJECT, since fields are used for
       // the keys
@@ -711,7 +722,12 @@ public class MetaschemaJsonReader
         IBoundInstanceFlag jsonKey = instance.getItemJsonKey(item);
         assert jsonKey != null;
 
-        String key = ObjectUtils.requireNonNull(jsonKey.getValue(item)).toString();
+        Object keyValue = jsonKey.getValue(item);
+        if (keyValue == null) {
+          throw new IOException(String.format("Null JSON key value for definition '%s'",
+              jsonKey.getContainingDefinition().toCoordinates()));
+        }
+        String key = jsonKey.getJavaTypeAdapter().asString(keyValue);
         items.put(key, item);
 
         // the next item will be a FIELD_NAME, or we will encounter an END_OBJECT if all

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonReader.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonReader.java
@@ -394,12 +394,12 @@ public class MetaschemaJsonReader
       JsonParser parser = getReader();
       ObjectNode node = parser.readValueAsTree();
 
-      String descriminatorProperty = instance.getJsonDiscriminatorProperty();
-      JsonNode descriminatorNode = node.get(descriminatorProperty);
-      if (descriminatorNode == null) {
+      String discriminatorProperty = instance.getJsonDiscriminatorProperty();
+      JsonNode discriminatorNode = node.get(discriminatorProperty);
+      if (discriminatorNode == null) {
         throw new IllegalArgumentException(String.format(
-            "Unable to find descriminator property '%s' for object at '%s'.",
-            descriminatorProperty,
+            "Unable to find discriminator property '%s' for object at '%s'.",
+            discriminatorProperty,
             JsonUtil.toString(parser)));
       }
       String discriminator = ObjectUtils.requireNonNull(descriminatorNode.asText());
@@ -724,7 +724,7 @@ public class MetaschemaJsonReader
 
         Object keyValue = jsonKey.getValue(item);
         if (keyValue == null) {
-          throw new IOException(String.format("Null JSON key value for definition '%s'",
+          throw new IOException(String.format("Null value for json-key for definition '%s'",
               jsonKey.getContainingDefinition().toCoordinates()));
         }
         String key = jsonKey.getJavaTypeAdapter().asString(keyValue);

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonReader.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonReader.java
@@ -439,8 +439,7 @@ public class MetaschemaJsonReader
       @Override
       public void accept(IBoundDefinitionModelComplex definition, Object parentItem, IJsonProblemHandler problemHandler)
           throws IOException {
-        @SuppressWarnings("resource")
-        JsonParser parser = getReader();
+        @SuppressWarnings("resource") JsonParser parser = getReader();
         JsonUtil.assertCurrent(parser, JsonToken.FIELD_NAME);
 
         // the field will be the JSON key
@@ -477,8 +476,7 @@ public class MetaschemaJsonReader
           Object parentItem,
           IJsonProblemHandler problemHandler)
           throws IOException {
-        @SuppressWarnings("resource")
-        JsonParser parser = getReader();
+        @SuppressWarnings("resource") JsonParser parser = getReader();
 
         // advance past the start object
         JsonUtil.assertAndAdvance(parser, JsonToken.START_OBJECT);
@@ -602,8 +600,7 @@ public class MetaschemaJsonReader
         if (foundJsonValueKey) {
           retval = delegate.handleUnknownProperty(definition, parentItem, fieldName, reader);
         } else {
-          @SuppressWarnings("resource")
-          JsonParser parser = getReader();
+          @SuppressWarnings("resource") JsonParser parser = getReader();
           // handle JSON value key
           String key = ObjectUtils.notNull(parser.getCurrentName());
           Object keyValue = jsonValueKyeFlag.getJavaTypeAdapter().parse(key);
@@ -703,8 +700,7 @@ public class MetaschemaJsonReader
 
       IBoundInstanceModel instance = getCollectionInfo().getInstance();
 
-      @SuppressWarnings("PMD.UseConcurrentHashMap")
-      Map<String, Object> items = new LinkedHashMap<>();
+      @SuppressWarnings("PMD.UseConcurrentHashMap") Map<String, Object> items = new LinkedHashMap<>();
 
       // A map value is always wrapped in a START_OBJECT, since fields are used for
       // the keys

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonReader.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonReader.java
@@ -402,7 +402,7 @@ public class MetaschemaJsonReader
             discriminatorProperty,
             JsonUtil.toString(parser)));
       }
-      String discriminator = ObjectUtils.requireNonNull(descriminatorNode.asText());
+      String discriminator = ObjectUtils.requireNonNull(discriminatorNode.asText());
 
       IBoundInstanceModelGroupedNamed actualInstance = instance.getGroupedModelInstance(discriminator);
       assert actualInstance != null;
@@ -439,7 +439,8 @@ public class MetaschemaJsonReader
       @Override
       public void accept(IBoundDefinitionModelComplex definition, Object parentItem, IJsonProblemHandler problemHandler)
           throws IOException {
-        @SuppressWarnings("resource") JsonParser parser = getReader();
+        @SuppressWarnings("resource")
+        JsonParser parser = getReader();
         JsonUtil.assertCurrent(parser, JsonToken.FIELD_NAME);
 
         // the field will be the JSON key
@@ -476,7 +477,8 @@ public class MetaschemaJsonReader
           Object parentItem,
           IJsonProblemHandler problemHandler)
           throws IOException {
-        @SuppressWarnings("resource") JsonParser parser = getReader();
+        @SuppressWarnings("resource")
+        JsonParser parser = getReader();
 
         // advance past the start object
         JsonUtil.assertAndAdvance(parser, JsonToken.START_OBJECT);
@@ -600,7 +602,8 @@ public class MetaschemaJsonReader
         if (foundJsonValueKey) {
           retval = delegate.handleUnknownProperty(definition, parentItem, fieldName, reader);
         } else {
-          @SuppressWarnings("resource") JsonParser parser = getReader();
+          @SuppressWarnings("resource")
+          JsonParser parser = getReader();
           // handle JSON value key
           String key = ObjectUtils.notNull(parser.getCurrentName());
           Object keyValue = jsonValueKyeFlag.getJavaTypeAdapter().parse(key);
@@ -700,7 +703,8 @@ public class MetaschemaJsonReader
 
       IBoundInstanceModel instance = getCollectionInfo().getInstance();
 
-      @SuppressWarnings("PMD.UseConcurrentHashMap") Map<String, Object> items = new LinkedHashMap<>();
+      @SuppressWarnings("PMD.UseConcurrentHashMap")
+      Map<String, Object> items = new LinkedHashMap<>();
 
       // A map value is always wrapped in a START_OBJECT, since fields are used for
       // the keys

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonWriter.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonWriter.java
@@ -29,7 +29,6 @@ package gov.nist.secauto.metaschema.databind.io.json;
 import com.fasterxml.jackson.core.JsonGenerator;
 
 import gov.nist.secauto.metaschema.core.model.JsonGroupAsBehavior;
-import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.model.IBoundDefinitionModelAssembly;
 import gov.nist.secauto.metaschema.databind.model.IBoundDefinitionModelFieldComplex;
 import gov.nist.secauto.metaschema.databind.model.IBoundFieldValue;
@@ -128,8 +127,13 @@ public class MetaschemaJsonWriter implements IJsonWritingContext {
 
       String valueKeyName;
       if (jsonValueKey != null) {
+        Object keyValue = jsonValueKey.getValue(parentItem);
+        if (keyValue == null) {
+          throw new IOException(String.format("Null JSON value key value for definition '%s'",
+              jsonValueKey.getContainingDefinition().toCoordinates()));
+        }
         // this is the JSON value key case
-        valueKeyName = ObjectUtils.requireNonNull(jsonValueKey.getValue(parentItem)).toString();
+        valueKeyName = jsonValueKey.getJavaTypeAdapter().asString(keyValue);
       } else {
         valueKeyName = fieldValue.getParentFieldDefinition().getEffectiveJsonValueKeyName();
       }
@@ -253,8 +257,9 @@ public class MetaschemaJsonWriter implements IJsonWritingContext {
       actualInstance.writeItem(item, this);
     }
 
-    private void writeScalarItem(Object item, IFeatureScalarItemValueHandler handler) throws IOException {
-      handler.getJavaTypeAdapter().writeJsonValue(ObjectUtils.requireNonNull(item), writer);
+    private void writeScalarItem(@NonNull Object item, @NonNull IFeatureScalarItemValueHandler handler)
+        throws IOException {
+      handler.getJavaTypeAdapter().writeJsonValue(item, writer);
     }
 
     private <T extends IBoundInstanceModelGroupedNamed> void writeDiscriminatorProperty(
@@ -297,8 +302,14 @@ public class MetaschemaJsonWriter implements IJsonWritingContext {
 
       IBoundInstanceFlag jsonKey = handler.getItemJsonKey(parentItem);
       if (jsonKey != null) {
+        Object keyValue = jsonKey.getValue(parentItem);
+        if (keyValue == null) {
+          throw new IOException(String.format("Null JSON key value for definition '%s'",
+              jsonKey.getContainingDefinition().toCoordinates()));
+        }
+
         // the field will be the JSON key value
-        String key = jsonKey.getJavaTypeAdapter().asString(ObjectUtils.requireNonNull(jsonKey.getValue(parentItem)));
+        String key = jsonKey.getJavaTypeAdapter().asString(keyValue);
         writer.writeFieldName(key);
 
         // next the value will be a start object
@@ -323,8 +334,14 @@ public class MetaschemaJsonWriter implements IJsonWritingContext {
       IBoundInstanceModelChoiceGroup choiceGroup = handler.getParentContainer();
       IBoundInstanceFlag jsonKey = choiceGroup.getItemJsonKey(parentItem);
       if (jsonKey != null) {
+        Object keyValue = jsonKey.getValue(parentItem);
+        if (keyValue == null) {
+          throw new IOException(String.format("Null JSON key value for definition '%s'",
+              jsonKey.getContainingDefinition().toCoordinates()));
+        }
+
         // the field will be the JSON key value
-        String key = jsonKey.getJavaTypeAdapter().asString(ObjectUtils.requireNonNull(jsonKey.getValue(parentItem)));
+        String key = jsonKey.getJavaTypeAdapter().asString(keyValue);
         writer.writeFieldName(key);
 
         // next the value will be a start object

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonWriter.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonWriter.java
@@ -129,7 +129,7 @@ public class MetaschemaJsonWriter implements IJsonWritingContext {
       if (jsonValueKey != null) {
         Object keyValue = jsonValueKey.getValue(parentItem);
         if (keyValue == null) {
-          throw new IOException(String.format("Null JSON value key value for definition '%s'",
+          throw new IOException(String.format("Null value for json-value-key for definition '%s'",
               jsonValueKey.getContainingDefinition().toCoordinates()));
         }
         // this is the JSON value key case
@@ -304,7 +304,7 @@ public class MetaschemaJsonWriter implements IJsonWritingContext {
       if (jsonKey != null) {
         Object keyValue = jsonKey.getValue(parentItem);
         if (keyValue == null) {
-          throw new IOException(String.format("Null JSON key value for definition '%s'",
+          throw new IOException(String.format("Null value for json-key for definition '%s'",
               jsonKey.getContainingDefinition().toCoordinates()));
         }
 
@@ -336,7 +336,7 @@ public class MetaschemaJsonWriter implements IJsonWritingContext {
       if (jsonKey != null) {
         Object keyValue = jsonKey.getValue(parentItem);
         if (keyValue == null) {
-          throw new IOException(String.format("Null JSON key value for definition '%s'",
+          throw new IOException(String.format("Null value for json-key for definition '%s'",
               jsonKey.getContainingDefinition().toCoordinates()));
         }
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/BindingModule.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/BindingModule.java
@@ -183,12 +183,20 @@ public class BindingModule
 
   @Override
   public MarkupLine getName() {
-    return ObjectUtils.requireNonNull(getBinding().getSchemaName());
+    MarkupLine retval = getBinding().getSchemaName();
+    if (retval == null) {
+      throw new IllegalStateException(String.format("The schema name is NULL for module '%s'.", getLocation()));
+    }
+    return retval;
   }
 
   @Override
   public String getVersion() {
-    return ObjectUtils.requireNonNull(getBinding().getSchemaVersion());
+    String retval = getBinding().getSchemaVersion();
+    if (retval == null) {
+      throw new IllegalStateException(String.format("The schema version is NULL for module '%s'.", getLocation()));
+    }
+    return retval;
   }
 
   @Override
@@ -198,17 +206,30 @@ public class BindingModule
 
   @Override
   public String getShortName() {
-    return ObjectUtils.requireNonNull(getBinding().getShortName());
+    String retval = getBinding().getShortName();
+    if (retval == null) {
+      throw new IllegalStateException(String.format("The schema short name is NULL for module '%s'.", getLocation()));
+    }
+    return retval;
   }
 
   @Override
   public URI getXmlNamespace() {
-    return ObjectUtils.requireNonNull(getBinding().getNamespace());
+    URI retval = getBinding().getNamespace();
+    if (retval == null) {
+      throw new IllegalStateException(
+          String.format("The XML schema namespace is NULL for module '%s'.", getLocation()));
+    }
+    return retval;
   }
 
   @Override
   public URI getJsonBaseUri() {
-    return ObjectUtils.requireNonNull(getBinding().getJsonBaseUri());
+    URI retval = getBinding().getJsonBaseUri();
+    if (retval == null) {
+      throw new IllegalStateException(String.format("The JSON schema URI is NULL for module '%s'.", getLocation()));
+    }
+    return retval;
   }
 
   @NonNull

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/model/AbstractBoundModelTestSupport.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/model/AbstractBoundModelTestSupport.java
@@ -76,7 +76,12 @@ public class AbstractBoundModelTestSupport {
 
   @NonNull
   protected IBoundDefinitionModel registerClassBinding(@NonNull Class<?> clazz) {
-    return ObjectUtils.requireNonNull(getBindingContext().getBoundDefinitionForClass(clazz));
+    IBoundDefinitionModel definition = getBindingContext().getBoundDefinitionForClass(clazz);
+    if (definition == null) {
+      throw new IllegalArgumentException(String.format("Unable to find bound definition for class '%s'.",
+          clazz.getName()));
+    }
+    return definition;
   }
 
   @NonNull

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/AbstractModelDefinitionJsonSchema.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/AbstractModelDefinitionJsonSchema.java
@@ -71,7 +71,13 @@ public abstract class AbstractModelDefinitionJsonSchema<D extends IModelDefiniti
 
     // determine the flag instances to generate
     if (jsonKeyFlagName != null) {
-      IFlagInstance jsonKeyFlag = ObjectUtils.requireNonNull(definition.getFlagInstanceByName(jsonKeyFlagName));
+      IFlagInstance jsonKeyFlag = definition.getFlagInstanceByName(jsonKeyFlagName);
+      if (jsonKeyFlag == null) {
+        throw new IllegalArgumentException(
+            String.format("The referenced JSON key flag '%s' does not exist on definition '%s'.",
+                jsonKeyFlagName,
+                definition.getName()));
+      }
       flagStream = flagStream.filter(instance -> instance != jsonKeyFlag);
     }
 

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/AbstractModelDefinitionJsonSchema.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/AbstractModelDefinitionJsonSchema.java
@@ -74,7 +74,7 @@ public abstract class AbstractModelDefinitionJsonSchema<D extends IModelDefiniti
       IFlagInstance jsonKeyFlag = definition.getFlagInstanceByName(jsonKeyFlagName);
       if (jsonKeyFlag == null) {
         throw new IllegalArgumentException(
-            String.format("The referenced JSON key flag '%s' does not exist on definition '%s'.",
+            String.format("The referenced json-key flag-name '%s' does not exist on definition '%s'.",
                 jsonKeyFlagName,
                 definition.getName()));
       }


### PR DESCRIPTION
# Committer Notes

In the Metaschema data binding code, missing expected data will generate a NullPointerException. This PR improves these errors to provide more information about the cause of the null value.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
