### PR TITLE
Bump jackson and thymeleaf versions

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractModuleLoader.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractModuleLoader.java
@@ -118,8 +118,7 @@ public abstract class AbstractModuleLoader<T, M extends IModuleExtended<M, ?, ?,
 
     // now check if this Metaschema imports other metaschema
     List<URI> imports = getImports(binding);
-    @NonNull
-    Map<URI, M> importedModules;
+    @NonNull Map<URI, M> importedModules;
     if (imports.isEmpty()) {
       importedModules = ObjectUtils.notNull(Collections.emptyMap());
     } else {

--- a/pom.xml
+++ b/pom.xml
@@ -127,8 +127,7 @@
 		<dependency.flexmark.version>0.64.8</dependency.flexmark.version>
 		<dependency.freemarker.version>2.3.32</dependency.freemarker.version>
 		<dependency.inject-resources-junit-jupiter.version>0.3.3</dependency.inject-resources-junit-jupiter.version>
-		<dependency.jackson.version>2.15.2</dependency.jackson.version>
-		<dependency.jackson-databind.version>2.15.2</dependency.jackson-databind.version>
+		<dependency.jackson.version>2.16.1</dependency.jackson.version>
 		<dependency.jansi.version>2.4.1</dependency.jansi.version>
 		<dependency.jaxb.version>4.0.0</dependency.jaxb.version>
 		<dependency.jaxen.version>2.0.0</dependency.jaxen.version>
@@ -144,7 +143,7 @@
 		<dependency.saxon.version>12.4</dependency.saxon.version>
 		<dependency.spotbugs-annotations.version>4.8.3</dependency.spotbugs-annotations.version>
 		<dependency.stax2-api.version>4.2.2</dependency.stax2-api.version>
-		<dependency.thymeleaf.version>3.0.15.RELEASE</dependency.thymeleaf.version>
+		<dependency.thymeleaf.version>3.1.2.RELEASE</dependency.thymeleaf.version>
 		<dependency.woodstox.version>6.5.1</dependency.woodstox.version>
 		<dependency.xmlbeans.version>5.2.0</dependency.xmlbeans.version>
 		<dependency.xmlcalabash.version>1.5.7-120</dependency.xmlcalabash.version>
@@ -375,7 +374,7 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>${dependency.jackson-databind.version}</version>
+				<version>${dependency.jackson.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
# Committer Notes

This PR bumps the Jackson version from 2.15.2 to 2.16.1 and thymeleaf from 3.0.15 to 3.1.2.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
