### PR TITLE
Fix use of --help with missing required command arguments

### DIFF
--- a/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
+++ b/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
@@ -70,10 +70,10 @@ public class CLITest {
       {
         add(Arguments.of(new String[] {}, ExitCode.INVALID_COMMAND, NO_EXCEPTION_CLASS));
         add(Arguments.of(new String[] { "-h" }, ExitCode.OK, NO_EXCEPTION_CLASS));
-        add(Arguments.of(new String[] { "generate-schema", "--help" }, ExitCode.INVALID_COMMAND,
+        add(Arguments.of(new String[] { "generate-schema", "--help" }, ExitCode.OK,
             NO_EXCEPTION_CLASS));
         add(Arguments.of(new String[] { "validate", "--help" }, ExitCode.OK, NO_EXCEPTION_CLASS));
-        add(Arguments.of(new String[] { "validate-content", "--help" }, ExitCode.INVALID_COMMAND,
+        add(Arguments.of(new String[] { "validate-content", "--help" }, ExitCode.OK,
             NO_EXCEPTION_CLASS));
         add(Arguments.of(
             new String[] { "validate",


### PR DESCRIPTION
# Committer Notes

This PR addresses #293 by implementing a two phase approach to parsing command line arguments. The first phase checks if `--help` or `--version` is provided, while the second phase handles actual command processing. If `--help` or `--version` is found in the first phase, the help or version information will be provided; else, the command execution will proceed.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
